### PR TITLE
Fix variable scope and datetime serialization issues

### DIFF
--- a/apps/post-ingestion/recent_ingest.py
+++ b/apps/post-ingestion/recent_ingest.py
@@ -117,6 +117,7 @@ def ingest_recent_posts(
     logger.info(f"Parsed {len(posts_data)} posts")
 
     # Insert posts to database
+    posts_inserted = 0
     if posts_data:
         logger.info(f"Inserting {len(posts_data)} posts to database...")
         try:


### PR DESCRIPTION
- Initialize posts_inserted before try block to avoid UnboundLocalError
- Add _serialize_for_json helper to convert datetime to ISO strings
- Apply serialization to both posts and comments before Supabase insert

Fixes:
- 'posts_inserted' referenced before assignment error
- 'datetime is not JSON serializable' error