### PR TITLE
feat(config): Replace GLM-4.5-Air (paid) with GLM-4.7-Flash (free)

### DIFF
--- a/apps/post-extraction/api.py
+++ b/apps/post-extraction/api.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""FastAPI service for post extraction using GLM-4.5-Air (replaces Claude)."""
+"""FastAPI service for post extraction using GLM-4.7-Flash (replaces Claude)."""
 
 import os
 import sys
+import time
 from pathlib import Path
 from datetime import datetime
 from fastapi import FastAPI, HTTPException, BackgroundTasks
@@ -34,7 +35,7 @@ async def startup_event():
     logger.info("=" * 80)
     logger.info("🚀 POST EXTRACTION SERVICE STARTING UP")
     logger.info(f"   Service: post-extraction")
-    logger.info(f"   Model: GLM-4.5-Air")
+    logger.info(f"   Model: GLM-4.7-Flash")
     logger.info(f"   Port: {os.getenv('PORT', '8004')}")
     logger.info(f"   Time: {datetime.now().isoformat()}")
     logger.info("=" * 80)
@@ -59,7 +60,7 @@ _extraction_running = False
 
 @app.get("/health")
 async def health_check():
-    return {"status": "healthy", "service": "post-extraction", "model": "glm-4.5-air"}
+    return {"status": "healthy", "service": "post-extraction", "model": "glm-4.7-flash"}
 
 
 @app.post("/api/extract")
@@ -309,6 +310,10 @@ async def trigger_extraction(
                         f"❌ Failed to extract {post_id}: {str(e)}", exc_info=True
                     )
 
+                # Rate limit: GLM-4.7-Flash free tier allows 1 concurrent request
+                if i < len(posts):
+                    time.sleep(2.0)
+
             db.close()
             logger.info("🔌 Database connection closed")
 
@@ -345,7 +350,7 @@ async def trigger_extraction(
 
     background_tasks.add_task(run_extraction)
     logger.info("✅ Extraction task queued successfully")
-    return {"status": "started", "message": f"Extraction started with GLM-4.5-Air"}
+    return {"status": "started", "message": f"Extraction started with GLM-4.7-Flash"}
 
 
 @app.get("/api/status")

--- a/apps/post-extraction/glm_client.py
+++ b/apps/post-extraction/glm_client.py
@@ -1,10 +1,10 @@
 """
-GLM-4.5-Air client for post feature extraction (replaces Claude).
+GLM-4.7-Flash client for post feature extraction (replaces Claude).
 
 Cost comparison:
 - Claude Sonnet 4: $3/$15 per 1M tokens
+- GLM-4.7-Flash: Free tier (1 concurrent request)
 - GLM-4.5-Air: $0.20/$1.10 per 1M tokens
-- Savings: ~15x cheaper
 """
 
 import os
@@ -25,14 +25,15 @@ load_dotenv(env_path)
 logger = get_logger(__name__)
 
 MODEL_PRICING = {
+    "glm-4.7-flash": {"input": 0.0, "output": 0.0},  # Free tier
     "glm-4.5-air": {"input": 0.20, "output": 1.10},
     "glm-4.5": {"input": 0.60, "output": 2.20},
 }
 
-DEFAULT_MODEL = "glm-4.5-air"
+DEFAULT_MODEL = "glm-4.7-flash"
 
 class GLMClient:
-    """GLM-4.5-Air client for extracting features from Reddit posts."""
+    """GLM-4.7-Flash client for extracting features from Reddit posts."""
 
     def __init__(self, api_key: Optional[str] = None):
         self.api_key = api_key or os.getenv("GLM_API_KEY")
@@ -47,11 +48,11 @@ class GLMClient:
 
     def extract_features(self, prompts: tuple[str, str] | str, model: Optional[str] = None, max_retries: int = 3) -> Tuple[ExtractedFeatures, Dict[str, Any]]:
         """
-        Extract features using GLM-4.5-Air.
+        Extract features using GLM-4.7-Flash.
 
         Args:
             prompts: Either a tuple of (system_prompt, user_prompt) or just user_prompt string
-            model: GLM model to use (defaults to glm-4.5-air)
+            model: GLM model to use (defaults to glm-4.7-flash)
             max_retries: Number of retry attempts on failure
 
         Returns:

--- a/apps/post-extraction/start.sh
+++ b/apps/post-extraction/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-echo "Starting WhichGLP Post Extraction Service (GLM-4.5-Air)..."
+echo "Starting WhichGLP Post Extraction Service (GLM-4.7-Flash)..."
 if [ -d "../../venv" ]; then
     source ../../venv/bin/activate
 fi

--- a/apps/user-extraction/api.py
+++ b/apps/user-extraction/api.py
@@ -48,7 +48,7 @@ async def startup_event():
     logger.info("🚀 USER EXTRACTION SERVICE STARTING UP")
     logger.info(f"   Service: user-extraction")
     logger.info(f"   Port: {os.getenv('PORT', '8002')}")
-    logger.info(f"   Model: GLM-4.5-Air")
+    logger.info(f"   Model: GLM-4.7-Flash")
     logger.info(f"   Time: {datetime.now().isoformat()}")
     logger.info("=" * 80)
 

--- a/apps/user-extraction/glm_client.py
+++ b/apps/user-extraction/glm_client.py
@@ -1,11 +1,11 @@
 """
-GLM-4.5-Air client for extracting demographic data from Reddit user history.
+GLM-4.7-Flash client for extracting demographic data from Reddit user history.
 
-This module provides a wrapper around the Z.AI SDK (GLM-4.5-Air) with:
+This module provides a wrapper around the Z.AI SDK (GLM-4.7-Flash) with:
 - Cost tracking per API call
 - Automatic JSON parsing and validation
 - Error handling and retries
-- Significantly cheaper than Claude ($0.20/$1.10 vs $3/$15 per 1M tokens)
+- Free tier (1 concurrent request) vs Claude ($3/$15 per 1M tokens)
 """
 
 import os
@@ -27,8 +27,12 @@ load_dotenv(env_path)
 # Initialize logger
 logger = get_logger(__name__)
 
-# GLM model pricing (as of 2025, per million tokens)
+# GLM model pricing (as of 2026, per million tokens)
 MODEL_PRICING = {
+    "glm-4.7-flash": {
+        "input": 0.0,    # Free tier
+        "output": 0.0,   # Free tier
+    },
     "glm-4.5-air": {
         "input": 0.20,   # $0.20 per MTok
         "output": 1.10,  # $1.10 per MTok
@@ -40,7 +44,7 @@ MODEL_PRICING = {
 }
 
 # Default model
-DEFAULT_MODEL = "glm-4.5-air"
+DEFAULT_MODEL = "glm-4.7-flash"
 
 
 class GLMClientConfigurationError(Exception):
@@ -55,7 +59,7 @@ class GLMExtractionError(Exception):
 
 class GLMClient:
     """
-    Client for GLM-4.5-Air API with demographic data extraction.
+    Client for GLM-4.7-Flash API with demographic data extraction.
 
     Handles API calls, cost tracking, JSON parsing, and Pydantic validation.
     """
@@ -100,7 +104,7 @@ class GLMClient:
             Cost in USD
         """
         if model not in MODEL_PRICING:
-            logger.warning(f"Unknown model {model}, using glm-4.5-air pricing")
+            logger.warning(f"Unknown model {model}, using glm-4.7-flash pricing")
             pricing = MODEL_PRICING[DEFAULT_MODEL]
         else:
             pricing = MODEL_PRICING[model]
@@ -121,7 +125,7 @@ class GLMClient:
 
         Args:
             user_prompt: Formatted prompt with user's posts/comments
-            model: GLM model to use (defaults to glm-4.5-air)
+            model: GLM model to use (defaults to glm-4.7-flash)
             max_retries: Number of retries on failure
 
         Returns:

--- a/apps/user-extraction/user_analyzer.py
+++ b/apps/user-extraction/user_analyzer.py
@@ -5,7 +5,7 @@ User demographics analyzer for Reddit users.
 This script:
 1. Fetches unique usernames from extracted_features table (users with already-extracted posts)
 2. Uses PRAW to get last 20 posts + 20 comments per user
-3. Sends to GLM-4.5-Air for demographic extraction
+3. Sends to GLM-4.7-Flash for demographic extraction
 4. Inserts results to reddit_users table
 """
 
@@ -40,7 +40,7 @@ class RedditUserAnalyzer:
     """
     Analyzes Reddit users to extract demographic information.
 
-    Uses PRAW to fetch user history and GLM-4.5-Air to extract demographics.
+    Uses PRAW to fetch user history and GLM-4.7-Flash to extract demographics.
     """
 
     def __init__(self):


### PR DESCRIPTION
## Summary
- Switch both **post-extraction** and **user-extraction** services from GLM-4.5-Air ($0.20/$1.10 per MTok) to GLM-4.7-Flash (free tier, 1 concurrent request)
- Add 2-second inter-request delay to post-extraction to respect the free tier's concurrency limit (user-extraction already had one)
- Update model references, pricing tables, and docstrings across 6 files

## Test plan
- [ ] Verify both services log `GLM-4.7-Flash` on startup
- [ ] Confirm `GET /health` on post-extraction returns `"model": "glm-4.7-flash"`
- [ ] Trigger small test runs: `POST /api/extract` with `{"limit": 3}` and `POST /api/analyze` with `{"limit": 3}`
- [ ] Check logs for `glm-4.7-flash` model name, `$0.000000` cost, and 2s delays between requests
- [ ] Verify new DB rows have `model_used = "glm-4.7-flash"` while historical rows retain `"glm-4.5-air"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)