### PR TITLE
fix(config): Increase GLM-4.7-Flash timeout

### DIFF
--- a/apps/post-extraction/api.py
+++ b/apps/post-extraction/api.py
@@ -56,6 +56,7 @@ class ExtractionRequest(BaseModel):
 
 
 _extraction_running = False
+GLM_RATE_LIMIT_DELAY = 5.0  # Seconds between requests (GLM-4.7-Flash free tier: 1 concurrent)
 
 
 @app.get("/health")
@@ -312,7 +313,7 @@ async def trigger_extraction(
 
                 # Rate limit: GLM-4.7-Flash free tier allows 1 concurrent request
                 if i < len(posts):
-                    time.sleep(5.0)
+                    time.sleep(GLM_RATE_LIMIT_DELAY)
 
             db.close()
             logger.info("🔌 Database connection closed")

--- a/apps/post-extraction/api.py
+++ b/apps/post-extraction/api.py
@@ -312,7 +312,7 @@ async def trigger_extraction(
 
                 # Rate limit: GLM-4.7-Flash free tier allows 1 concurrent request
                 if i < len(posts):
-                    time.sleep(2.0)
+                    time.sleep(5.0)
 
             db.close()
             logger.info("🔌 Database connection closed")

--- a/apps/user-extraction/user_analyzer.py
+++ b/apps/user-extraction/user_analyzer.py
@@ -330,7 +330,9 @@ class RedditUserAnalyzer:
             # This allows the pipeline to continue processing other users
             raise
 
-    def run(self, limit: Optional[int] = None, rate_limit_delay: float = 5.0):
+    GLM_RATE_LIMIT_DELAY = 5.0  # Seconds between requests (GLM-4.7-Flash free tier: 1 concurrent)
+
+    def run(self, limit: Optional[int] = None, rate_limit_delay: float = GLM_RATE_LIMIT_DELAY):
         """
         Run the full user analysis pipeline.
 
@@ -407,8 +409,8 @@ def main():
     parser.add_argument(
         "--rate-limit",
         type=float,
-        default=5.0,
-        help="Delay in seconds between users (default: 5.0)"
+        default=RedditUserAnalyzer.GLM_RATE_LIMIT_DELAY,
+        help=f"Delay in seconds between users (default: {RedditUserAnalyzer.GLM_RATE_LIMIT_DELAY})"
     )
 
     args = parser.parse_args()

--- a/apps/user-extraction/user_analyzer.py
+++ b/apps/user-extraction/user_analyzer.py
@@ -330,7 +330,7 @@ class RedditUserAnalyzer:
             # This allows the pipeline to continue processing other users
             raise
 
-    def run(self, limit: Optional[int] = None, rate_limit_delay: float = 2.0):
+    def run(self, limit: Optional[int] = None, rate_limit_delay: float = 5.0):
         """
         Run the full user analysis pipeline.
 
@@ -407,8 +407,8 @@ def main():
     parser.add_argument(
         "--rate-limit",
         type=float,
-        default=2.0,
-        help="Delay in seconds between users (default: 2.0)"
+        default=5.0,
+        help="Delay in seconds between users (default: 5.0)"
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- Increase inter-request delay from 2s to 5s in both post-extraction and user-extraction services to reduce 429 rate limit errors from Z.AI's GLM-4.7-Flash free tier

## Test plan
- [ ] Trigger extraction runs and verify no 429 errors in logs
- [ ] Confirm 5-second delays visible between requests in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)