### PR TITLE
Switch from GLM-4.7-Flash to GLM-4.7-FlashX

### DIFF
--- a/apps/post-extraction/api.py
+++ b/apps/post-extraction/api.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""FastAPI service for post extraction using GLM-4.7-Flash (replaces Claude)."""
+"""FastAPI service for post extraction using GLM-4.7-FlashX (replaces Claude)."""
 
 import os
 import sys
@@ -35,7 +35,7 @@ async def startup_event():
     logger.info("=" * 80)
     logger.info("🚀 POST EXTRACTION SERVICE STARTING UP")
     logger.info(f"   Service: post-extraction")
-    logger.info(f"   Model: GLM-4.7-Flash")
+    logger.info(f"   Model: GLM-4.7-FlashX")
     logger.info(f"   Port: {os.getenv('PORT', '8004')}")
     logger.info(f"   Time: {datetime.now().isoformat()}")
     logger.info("=" * 80)
@@ -56,12 +56,12 @@ class ExtractionRequest(BaseModel):
 
 
 _extraction_running = False
-GLM_RATE_LIMIT_DELAY = 5.0  # Seconds between requests (GLM-4.7-Flash free tier: 1 concurrent)
+GLM_RATE_LIMIT_DELAY = 5.0  # Seconds between requests (GLM-4.7-FlashX paid tier)
 
 
 @app.get("/health")
 async def health_check():
-    return {"status": "healthy", "service": "post-extraction", "model": "glm-4.7-flash"}
+    return {"status": "healthy", "service": "post-extraction", "model": "glm-4.7-flashx"}
 
 
 @app.post("/api/extract")
@@ -311,7 +311,7 @@ async def trigger_extraction(
                         f"❌ Failed to extract {post_id}: {str(e)}", exc_info=True
                     )
 
-                # Rate limit: GLM-4.7-Flash free tier allows 1 concurrent request
+                # Rate limit: GLM-4.7-FlashX paid tier
                 if i < len(posts):
                     time.sleep(GLM_RATE_LIMIT_DELAY)
 
@@ -351,7 +351,7 @@ async def trigger_extraction(
 
     background_tasks.add_task(run_extraction)
     logger.info("✅ Extraction task queued successfully")
-    return {"status": "started", "message": f"Extraction started with GLM-4.7-Flash"}
+    return {"status": "started", "message": f"Extraction started with GLM-4.7-FlashX"}
 
 
 @app.get("/api/status")

--- a/apps/post-extraction/glm_client.py
+++ b/apps/post-extraction/glm_client.py
@@ -1,9 +1,9 @@
 """
-GLM-4.7-Flash client for post feature extraction (replaces Claude).
+GLM-4.7-FlashX client for post feature extraction (replaces Claude).
 
 Cost comparison:
 - Claude Sonnet 4: $3/$15 per 1M tokens
-- GLM-4.7-Flash: Free tier (1 concurrent request)
+- GLM-4.7-FlashX: $0.07/$0.40 per 1M tokens
 - GLM-4.5-Air: $0.20/$1.10 per 1M tokens
 """
 
@@ -25,15 +25,16 @@ load_dotenv(env_path)
 logger = get_logger(__name__)
 
 MODEL_PRICING = {
+    "glm-4.7-flashx": {"input": 0.07, "output": 0.40},
     "glm-4.7-flash": {"input": 0.0, "output": 0.0},  # Free tier
     "glm-4.5-air": {"input": 0.20, "output": 1.10},
     "glm-4.5": {"input": 0.60, "output": 2.20},
 }
 
-DEFAULT_MODEL = "glm-4.7-flash"
+DEFAULT_MODEL = "glm-4.7-flashx"
 
 class GLMClient:
-    """GLM-4.7-Flash client for extracting features from Reddit posts."""
+    """GLM-4.7-FlashX client for extracting features from Reddit posts."""
 
     def __init__(self, api_key: Optional[str] = None):
         self.api_key = api_key or os.getenv("GLM_API_KEY")
@@ -48,11 +49,11 @@ class GLMClient:
 
     def extract_features(self, prompts: tuple[str, str] | str, model: Optional[str] = None, max_retries: int = 3) -> Tuple[ExtractedFeatures, Dict[str, Any]]:
         """
-        Extract features using GLM-4.7-Flash.
+        Extract features using GLM-4.7-FlashX.
 
         Args:
             prompts: Either a tuple of (system_prompt, user_prompt) or just user_prompt string
-            model: GLM model to use (defaults to glm-4.7-flash)
+            model: GLM model to use (defaults to glm-4.7-flashx)
             max_retries: Number of retry attempts on failure
 
         Returns:
@@ -124,9 +125,15 @@ class GLMClient:
                 return features, metadata
 
             except Exception as e:
-                logger.error(f"GLM error (attempt {attempt + 1}/{max_retries}): {e}")
+                is_rate_limit = "429" in str(e) or "rate limit" in str(e).lower()
+                if is_rate_limit:
+                    wait_time = 30 * (attempt + 1)
+                    logger.warning(f"Rate limited (attempt {attempt + 1}/{max_retries}), waiting {wait_time}s...")
+                else:
+                    wait_time = 5 * (attempt + 1)
+                    logger.error(f"GLM error (attempt {attempt + 1}/{max_retries}): {e}")
                 if attempt < max_retries - 1:
-                    time.sleep(5 * (attempt + 1))
+                    time.sleep(wait_time)
                 else:
                     raise
 

--- a/apps/post-extraction/start.sh
+++ b/apps/post-extraction/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-echo "Starting WhichGLP Post Extraction Service (GLM-4.7-Flash)..."
+echo "Starting WhichGLP Post Extraction Service (GLM-4.7-FlashX)..."
 if [ -d "../../venv" ]; then
     source ../../venv/bin/activate
 fi

--- a/apps/user-extraction/api.py
+++ b/apps/user-extraction/api.py
@@ -48,7 +48,7 @@ async def startup_event():
     logger.info("🚀 USER EXTRACTION SERVICE STARTING UP")
     logger.info(f"   Service: user-extraction")
     logger.info(f"   Port: {os.getenv('PORT', '8002')}")
-    logger.info(f"   Model: GLM-4.7-Flash")
+    logger.info(f"   Model: GLM-4.7-FlashX")
     logger.info(f"   Time: {datetime.now().isoformat()}")
     logger.info("=" * 80)
 

--- a/apps/user-extraction/glm_client.py
+++ b/apps/user-extraction/glm_client.py
@@ -1,11 +1,11 @@
 """
-GLM-4.7-Flash client for extracting demographic data from Reddit user history.
+GLM-4.7-FlashX client for extracting demographic data from Reddit user history.
 
-This module provides a wrapper around the Z.AI SDK (GLM-4.7-Flash) with:
+This module provides a wrapper around the Z.AI SDK (GLM-4.7-FlashX) with:
 - Cost tracking per API call
 - Automatic JSON parsing and validation
 - Error handling and retries
-- Free tier (1 concurrent request) vs Claude ($3/$15 per 1M tokens)
+- ~3x cheaper than GLM-4.5-Air ($0.07/$0.40 vs $0.20/$1.10 per 1M tokens)
 """
 
 import os
@@ -29,6 +29,10 @@ logger = get_logger(__name__)
 
 # GLM model pricing (as of 2026, per million tokens)
 MODEL_PRICING = {
+    "glm-4.7-flashx": {
+        "input": 0.07,   # $0.07 per MTok
+        "output": 0.40,  # $0.40 per MTok
+    },
     "glm-4.7-flash": {
         "input": 0.0,    # Free tier
         "output": 0.0,   # Free tier
@@ -44,7 +48,7 @@ MODEL_PRICING = {
 }
 
 # Default model
-DEFAULT_MODEL = "glm-4.7-flash"
+DEFAULT_MODEL = "glm-4.7-flashx"
 
 
 class GLMClientConfigurationError(Exception):
@@ -59,7 +63,7 @@ class GLMExtractionError(Exception):
 
 class GLMClient:
     """
-    Client for GLM-4.7-Flash API with demographic data extraction.
+    Client for GLM-4.7-FlashX API with demographic data extraction.
 
     Handles API calls, cost tracking, JSON parsing, and Pydantic validation.
     """
@@ -104,7 +108,7 @@ class GLMClient:
             Cost in USD
         """
         if model not in MODEL_PRICING:
-            logger.warning(f"Unknown model {model}, using glm-4.7-flash pricing")
+            logger.warning(f"Unknown model {model}, using glm-4.7-flashx pricing")
             pricing = MODEL_PRICING[DEFAULT_MODEL]
         else:
             pricing = MODEL_PRICING[model]
@@ -125,7 +129,7 @@ class GLMClient:
 
         Args:
             user_prompt: Formatted prompt with user's posts/comments
-            model: GLM model to use (defaults to glm-4.7-flash)
+            model: GLM model to use (defaults to glm-4.7-flashx)
             max_retries: Number of retries on failure
 
         Returns:
@@ -233,9 +237,14 @@ class GLMClient:
                 )
 
             except Exception as e:
-                logger.error(f"GLM API error (attempt {attempt + 1}/{max_retries}): {e}")
+                is_rate_limit = "429" in str(e) or "rate limit" in str(e).lower()
+                if is_rate_limit:
+                    wait_time = 30 * (attempt + 1)
+                    logger.warning(f"Rate limited (attempt {attempt + 1}/{max_retries}), waiting {wait_time}s...")
+                else:
+                    wait_time = 5 * (attempt + 1)
+                    logger.error(f"GLM API error (attempt {attempt + 1}/{max_retries}): {e}")
                 if attempt < max_retries - 1:
-                    wait_time = 5 * (attempt + 1)  # Exponential backoff
                     logger.info(f"Retrying in {wait_time}s...")
                     time.sleep(wait_time)
                 else:

--- a/apps/user-extraction/prompts.py
+++ b/apps/user-extraction/prompts.py
@@ -1,5 +1,5 @@
 """
-Prompts for GLM-4.5-Air to extract demographic data from Reddit user history.
+Prompts for GLM-4.7-FlashX to extract demographic data from Reddit user history.
 """
 
 SYSTEM_PROMPT = """You are a demographic data extraction assistant analyzing Reddit user post histories to build personalized medication recommendation profiles.

--- a/apps/user-extraction/schema.py
+++ b/apps/user-extraction/schema.py
@@ -1,7 +1,7 @@
 """
 Pydantic models for user demographic data extraction.
 
-This defines the schema that GLM-4.5-Air should extract from Reddit user histories.
+This defines the schema that GLM-4.7-FlashX should extract from Reddit user histories.
 """
 
 from typing import Optional, List
@@ -12,7 +12,7 @@ class UserDemographics(BaseModel):
     """
     Demographic data extracted from a Reddit user's post/comment history.
 
-    This is what we ask GLM-4.5-Air to extract from analyzing
+    This is what we ask GLM-4.7-FlashX to extract from analyzing
     a user's last 20 posts + 20 comments.
     """
 

--- a/apps/user-extraction/user_analyzer.py
+++ b/apps/user-extraction/user_analyzer.py
@@ -5,7 +5,7 @@ User demographics analyzer for Reddit users.
 This script:
 1. Fetches unique usernames from extracted_features table (users with already-extracted posts)
 2. Uses PRAW to get last 20 posts + 20 comments per user
-3. Sends to GLM-4.7-Flash for demographic extraction
+3. Sends to GLM-4.7-FlashX for demographic extraction
 4. Inserts results to reddit_users table
 """
 
@@ -40,7 +40,7 @@ class RedditUserAnalyzer:
     """
     Analyzes Reddit users to extract demographic information.
 
-    Uses PRAW to fetch user history and GLM-4.7-Flash to extract demographics.
+    Uses PRAW to fetch user history and GLM-4.7-FlashX to extract demographics.
     """
 
     def __init__(self):
@@ -330,7 +330,7 @@ class RedditUserAnalyzer:
             # This allows the pipeline to continue processing other users
             raise
 
-    GLM_RATE_LIMIT_DELAY = 5.0  # Seconds between requests (GLM-4.7-Flash free tier: 1 concurrent)
+    GLM_RATE_LIMIT_DELAY = 5.0  # Seconds between requests (GLM-4.7-FlashX paid tier)
 
     def run(self, limit: Optional[int] = None, rate_limit_delay: float = GLM_RATE_LIMIT_DELAY):
         """


### PR DESCRIPTION
## Summary
- **Why**: GLM-4.7-Flash free tier throttles aggressively — only 5 requests/minute and 500 requests/day, which is insufficient for our 1000+ posts/day volume
- **What**: Switch to GLM-4.7-FlashX ($0.07/$0.40 per MTok), which is still ~3x cheaper than GLM-4.5-Air ($0.20/$1.10) but without the free-tier throttling
- Add 429-specific retry backoff (30s/60s) in both glm_client.py files
- Set inter-request delay to 5s
- Update all model references and docstrings across 8 files

## Test plan
- [ ] Verify both services log `GLM-4.7-FlashX` on startup
- [ ] Confirm `GET /health` on post-extraction returns `"model": "glm-4.7-flashx"`
- [ ] Trigger test runs and verify no 429 errors
- [ ] Check new DB rows have `model_used = "glm-4.7-flashx"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)