### PR TITLE
fix(cron): Use session pooler for MV refresh instead of Supabase SDK

### DIFF
--- a/scripts/cron/view-refresher-cron.ts
+++ b/scripts/cron/view-refresher-cron.ts
@@ -1,57 +1,98 @@
-import { createClient } from "@supabase/supabase-js";
+import pg from "pg";
 import Redis from "ioredis";
 
-const SUPABASE_URL = process.env.SUPABASE_URL!;
-const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY!;
 const REDIS_URL = process.env.REDIS_URL;
+const MV_TIMEOUT_MS = parseInt(process.env.MV_TIMEOUT_MS || "300000", 10);
+
+const MATERIALIZED_VIEWS = ["mv_experiences_denormalized"];
+
+/**
+ * Build PG client config from environment variables.
+ *
+ * Uses the Supabase session pooler for direct PostgreSQL access,
+ * which avoids the ~8s timeout on the Supabase REST API / RPC.
+ */
+const buildClientConfig = (): pg.ClientConfig => {
+  // Option 1: Full connection string (preferred)
+  if (process.env.DATABASE_URL) {
+    console.log("   Using DATABASE_URL");
+    return {
+      connectionString: process.env.DATABASE_URL,
+      ssl: { rejectUnauthorized: false },
+      connectionTimeoutMillis: 30000,
+    };
+  }
+
+  // Option 2: Derive from SUPABASE_URL + SUPABASE_DB_PASSWORD (session pooler)
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const dbPassword = process.env.SUPABASE_DB_PASSWORD;
+
+  if (supabaseUrl && dbPassword) {
+    const projectId = new URL(supabaseUrl).hostname.split(".")[0];
+    const poolerHost = `aws-1-us-west-1.pooler.supabase.com`;
+    console.log(`   Using session pooler: ${poolerHost}:5432`);
+    return {
+      host: poolerHost,
+      port: 5432,
+      database: "postgres",
+      user: `postgres.${projectId}`,
+      password: dbPassword,
+      ssl: { rejectUnauthorized: false },
+      connectionTimeoutMillis: 30000,
+    };
+  }
+
+  throw new Error(
+    "Set DATABASE_URL or both SUPABASE_URL + SUPABASE_DB_PASSWORD"
+  );
+};
 
 const refreshCacheAndMaterializedView = async () => {
   console.log("=".repeat(80));
   console.log("🕐 CRON JOB STARTED - Refresh Cache & Materialized View");
   console.log(`   Time: ${new Date().toISOString()}`);
+  console.log(`   Timeout: ${MV_TIMEOUT_MS / 1000}s per view`);
+  console.log(`   Views: ${MATERIALIZED_VIEWS.join(", ")}`);
   console.log("=".repeat(80));
 
-  let supabase;
-  let redis;
+  let redis: Redis | undefined;
+  const clientConfig = buildClientConfig();
+  const client = new pg.Client(clientConfig);
 
   try {
-    // Initialize Supabase client
-    console.log("📡 Initializing Supabase client...");
-    supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+    // Connect to PostgreSQL via session pooler
+    console.log("📡 Connecting to PostgreSQL...");
+    await client.connect();
+    console.log("✅ Connected to PostgreSQL");
+
+    // Set statement timeout for long-running MV refreshes
+    await client.query(`SET statement_timeout = ${MV_TIMEOUT_MS}`);
+    console.log(`   Statement timeout set to ${MV_TIMEOUT_MS / 1000}s`);
 
     // Initialize Redis client (optional)
     if (REDIS_URL) {
       console.log("📡 Initializing Redis client...");
-      console.log(`   Redis URL: ${REDIS_URL.replace(/:[^:@]+@/, ":***@")}`); // Hide password
+      console.log(`   Redis URL: ${REDIS_URL.replace(/:[^:@]+@/, ":***@")}`);
 
       redis = new Redis(REDIS_URL, {
         retryStrategy: (times) => {
           console.log(`   Retry attempt ${times}/3...`);
-          // Stop retrying after 3 attempts
           if (times > 3) {
             console.warn(
               "⚠️  Redis connection failed after 3 attempts, giving up"
             );
             return null;
           }
-          // Exponential backoff, max 3 seconds
           return Math.min(times * 200, 3000);
         },
         maxRetriesPerRequest: 3,
-        // Railway IPv6 support - enable dual-stack DNS resolution
-        // https://docs.railway.com/reference/errors/enotfound-redis-railway-internal
         family: 0,
-        // Reduce keepAlive for Railway's timeout settings
         keepAlive: 30000,
-        // Don't wait too long for connections
         connectTimeout: 10000,
-        // Enable offline queue to buffer commands while connecting
         enableOfflineQueue: true,
-        // Connect immediately (not lazy)
         lazyConnect: false,
       });
 
-      // Add error handler to prevent unhandled error events
       redis.on("error", (err) => {
         console.error("Redis error event:", err.message || err);
       });
@@ -64,63 +105,91 @@ const refreshCacheAndMaterializedView = async () => {
         console.log("✅ Redis is ready");
       });
 
-      // Wait a moment for connection to establish
       await new Promise((resolve) => setTimeout(resolve, 1000));
     } else {
       console.warn("⚠️  REDIS_URL not set - skipping Redis cache deletion");
     }
 
-    // Refresh materialized view using RPC function
-    console.log(
-      "🔄 Refreshing materialized view: mv_experiences_denormalized..."
-    );
-    const { error: refreshError } = await supabase.rpc(
-      "refresh_materialized_view_function",
-      {
-        view_name: "mv_experiences_denormalized",
+    // Refresh materialized views
+    let successCount = 0;
+    let failCount = 0;
+
+    for (const mvName of MATERIALIZED_VIEWS) {
+      console.log(`\n🔄 Refreshing ${mvName}...`);
+      const start = Date.now();
+
+      try {
+        await client.query(
+          `REFRESH MATERIALIZED VIEW CONCURRENTLY ${mvName}`
+        );
+        const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+        console.log(`✅ ${mvName} refreshed in ${elapsed}s (concurrent)`);
+        successCount++;
+      } catch (concurrentErr) {
+        const errMsg =
+          concurrentErr instanceof Error
+            ? concurrentErr.message
+            : String(concurrentErr);
+
+        // CONCURRENTLY requires a unique index — fall back to regular refresh
+        if (errMsg.includes("unique index")) {
+          console.log(
+            `   CONCURRENTLY not supported, trying regular refresh...`
+          );
+          const start2 = Date.now();
+          try {
+            await client.query(`REFRESH MATERIALIZED VIEW ${mvName}`);
+            const elapsed2 = ((Date.now() - start2) / 1000).toFixed(1);
+            console.log(`✅ ${mvName} refreshed in ${elapsed2}s`);
+            successCount++;
+          } catch (regularErr) {
+            const elapsed2 = ((Date.now() - start2) / 1000).toFixed(1);
+            console.error(
+              `❌ ${mvName} failed after ${elapsed2}s: ${regularErr instanceof Error ? regularErr.message : String(regularErr)}`
+            );
+            failCount++;
+          }
+        } else {
+          const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+          console.error(`❌ ${mvName} failed after ${elapsed}s: ${errMsg}`);
+          failCount++;
+        }
       }
-    );
-
-    if (refreshError) {
-      throw new Error(
-        `Failed to refresh materialized view: ${refreshError.message}`
-      );
     }
-
-    console.log("✅ Materialized view refreshed successfully!");
 
     // Delete Redis cache key (if Redis is configured)
     if (redis) {
-      console.log("🗑️  Deleting Redis key: drugs:all-stats...");
+      console.log("\n🗑️  Deleting Redis key: drugs:all-stats...");
       try {
         const deletedCount = await redis.del("drugs:all-stats");
         console.log(`✅ Redis key deleted! (${deletedCount} key(s) removed)`);
       } catch (redisError) {
         console.error("❌ Failed to delete Redis key:", redisError);
-        // Don't fail the whole job if Redis deletion fails
         console.warn("⚠️  Continuing despite Redis error...");
       }
     } else {
       console.log("⏭️  Skipping Redis cache deletion (Redis not configured)");
     }
 
-    console.log("=".repeat(80));
-    console.log("🏁 CRON JOB COMPLETED");
+    console.log("\n" + "=".repeat(80));
+    console.log(
+      `🏁 CRON JOB COMPLETED - ${successCount} refreshed, ${failCount} failed`
+    );
     console.log("=".repeat(80));
 
-    process.exit(0);
+    await client.end();
+    if (redis) await redis.quit();
+    process.exit(failCount > 0 ? 1 : 0);
   } catch (error) {
     console.error("=".repeat(80));
     console.error("❌ CRON JOB FAILED");
     console.error("Error:", (error as Error).message);
     console.error("Stack:", (error as Error).stack);
     console.error("=".repeat(80));
+
+    await client.end().catch(() => {});
+    if (redis) await redis.quit().catch(() => {});
     process.exit(1);
-  } finally {
-    // Clean up Redis connection
-    if (redis) {
-      await redis.quit();
-    }
   }
 };
 


### PR DESCRIPTION
## Summary
- Replace Supabase SDK `rpc()` call with direct PostgreSQL via the session pooler (`pg` library)
- Supabase REST API has an ~8s timeout, too short for refreshing `mv_experiences_denormalized`
- Session pooler allows a 5-minute statement timeout (`MV_TIMEOUT_MS` env var, default 300s)
- Tries `REFRESH MATERIALIZED VIEW CONCURRENTLY` first, falls back to regular refresh if no unique index
- Keeps existing Redis cache deletion logic

## Test plan
- [ ] Install `pg` dependency: `bun add pg @types/pg` in `scripts/cron/`
- [ ] Set `DATABASE_URL` or `SUPABASE_URL` + `SUPABASE_DB_PASSWORD` env vars
- [ ] Run `bun view-refresher-cron.ts` and verify MV refreshes successfully
- [ ] Confirm Redis key `drugs:all-stats` is deleted after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)