### PR TITLE
feat(security): Harden with RLS and internal API key

### DIFF
--- a/apps/api/src/lib/supabase.ts
+++ b/apps/api/src/lib/supabase.ts
@@ -1,10 +1,10 @@
 import { createClient } from '@supabase/supabase-js'
 
 const supabaseUrl = process.env.SUPABASE_URL!
-const supabaseKey = process.env.SUPABASE_ANON_KEY!
+const supabaseKey = process.env.SUPABASE_SERVICE_KEY!
 
 if (!supabaseUrl || !supabaseKey) {
-  throw new Error('Missing Supabase environment variables')
+  throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_KEY environment variables')
 }
 
 export const supabase = createClient(supabaseUrl, supabaseKey)

--- a/apps/api/src/routers/recommendations.ts
+++ b/apps/api/src/routers/recommendations.ts
@@ -73,6 +73,7 @@ export const recommendationsRouter = router({
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            'x-internal-api-key': process.env.INTERNAL_API_KEY ?? '',
           },
           body: JSON.stringify(input),
         })

--- a/apps/post-extraction/api.py
+++ b/apps/post-extraction/api.py
@@ -6,7 +6,7 @@ import sys
 import time
 from pathlib import Path
 from datetime import datetime
-from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi import FastAPI, HTTPException, BackgroundTasks, Depends, Header
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -49,6 +49,15 @@ async def shutdown_event():
     logger.info("=" * 80)
 
 
+async def verify_internal_api_key(x_internal_api_key: str | None = Header(None)) -> None:
+    expected = os.getenv("INTERNAL_API_KEY")
+    if not expected:
+        print("[Auth] WARNING: INTERNAL_API_KEY not configured - skipping validation")
+        return
+    if not x_internal_api_key or x_internal_api_key != expected:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+
 class ExtractionRequest(BaseModel):
     subreddit: str | None = None
     limit: int | None = None
@@ -64,7 +73,7 @@ async def health_check():
     return {"status": "healthy", "service": "post-extraction", "model": "glm-4.7-flashx"}
 
 
-@app.post("/api/extract")
+@app.post("/api/extract", dependencies=[Depends(verify_internal_api_key)])
 async def trigger_extraction(
     request: ExtractionRequest, background_tasks: BackgroundTasks
 ):
@@ -354,7 +363,7 @@ async def trigger_extraction(
     return {"status": "started", "message": f"Extraction started with GLM-4.7-FlashX"}
 
 
-@app.get("/api/status")
+@app.get("/api/status", dependencies=[Depends(verify_internal_api_key)])
 async def get_status():
     return {"extraction_running": _extraction_running}
 

--- a/apps/post-ingestion/api.py
+++ b/apps/post-ingestion/api.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Optional, List
 from datetime import datetime
 
-from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi import FastAPI, HTTPException, BackgroundTasks, Depends, Header
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -40,6 +40,15 @@ async def shutdown_event():
     logger.info(f"   Time: {datetime.now().isoformat()}")
     logger.info("=" * 80)
 
+async def verify_internal_api_key(x_internal_api_key: Optional[str] = Header(None)) -> None:
+    expected = os.getenv("INTERNAL_API_KEY")
+    if not expected:
+        print("[Auth] WARNING: INTERNAL_API_KEY not configured - skipping validation")
+        return
+    if not x_internal_api_key or x_internal_api_key != expected:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+
 class IngestRequest(BaseModel):
     subreddit: Optional[str] = None
     posts_limit: int = 100
@@ -54,7 +63,7 @@ _ingestion_running = False
 async def health_check():
     return {"status": "healthy", "service": "post-ingestion"}
 
-@app.post("/api/ingest")
+@app.post("/api/ingest", dependencies=[Depends(verify_internal_api_key)])
 async def trigger_ingestion(request: IngestRequest, background_tasks: BackgroundTasks):
     global _ingestion_running
 
@@ -126,7 +135,7 @@ async def trigger_ingestion(request: IngestRequest, background_tasks: Background
     logger.info("✅ Ingestion task queued successfully")
     return {"status": "started", "message": f"Ingestion started"}
 
-@app.get("/api/status")
+@app.get("/api/status", dependencies=[Depends(verify_internal_api_key)])
 async def get_status():
     return {"ingestion_running": _ingestion_running}
 

--- a/apps/rec-engine/api.py
+++ b/apps/rec-engine/api.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import List, Optional
 
 import pandas as pd
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends, Header
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from supabase import create_client, Client
@@ -79,6 +79,15 @@ class RecommendationsResponse(BaseModel):
     processingTime: Optional[float] = None
 
 
+async def verify_internal_api_key(x_internal_api_key: Optional[str] = Header(None)) -> None:
+    expected = os.getenv("INTERNAL_API_KEY")
+    if not expected:
+        print("[Auth] WARNING: INTERNAL_API_KEY not configured - skipping validation")
+        return
+    if not x_internal_api_key or x_internal_api_key != expected:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+
 # Initialize Supabase (cached)
 _supabase_client: Optional[Client] = None
 
@@ -89,10 +98,10 @@ def get_supabase_client() -> Client:
 
     if _supabase_client is None:
         url = os.getenv("SUPABASE_URL")
-        key = os.getenv("SUPABASE_ANON_KEY") or os.getenv("SUPABASE_SERVICE_KEY")
+        key = os.getenv("SUPABASE_SERVICE_KEY")
 
         if not url or not key:
-            raise ValueError("Missing SUPABASE_URL or SUPABASE_ANON_KEY environment variables")
+            raise ValueError("Missing SUPABASE_URL or SUPABASE_SERVICE_KEY environment variables")
 
         _supabase_client = create_client(url, key)
 
@@ -146,7 +155,7 @@ async def health_check():
     return {"status": "healthy", "service": "rec-engine-api"}
 
 
-@app.post("/api/recommendations", response_model=RecommendationsResponse)
+@app.post("/api/recommendations", response_model=RecommendationsResponse, dependencies=[Depends(verify_internal_api_key)])
 async def get_recommendations(request: RecommendationRequest):
     """
     Generate drug recommendations based on user profile.
@@ -197,7 +206,7 @@ async def get_recommendations(request: RecommendationRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.get("/api/cache/clear")
+@app.get("/api/cache/clear", dependencies=[Depends(verify_internal_api_key)])
 async def clear_cache():
     """Clear the experiences cache (admin endpoint)."""
     global _experiences_cache

--- a/apps/shared/migrations/032_enable_rls.down.sql
+++ b/apps/shared/migrations/032_enable_rls.down.sql
@@ -1,0 +1,14 @@
+DROP POLICY IF EXISTS "reddit_posts_service_role_all" ON reddit_posts;
+DROP POLICY IF EXISTS "reddit_comments_service_role_all" ON reddit_comments;
+DROP POLICY IF EXISTS "extracted_features_service_role_all" ON extracted_features;
+DROP POLICY IF EXISTS "reddit_users_service_role_all" ON reddit_users;
+DROP POLICY IF EXISTS "platform_config_service_role_all" ON platform_config;
+
+ALTER TABLE reddit_posts DISABLE ROW LEVEL SECURITY;
+ALTER TABLE reddit_comments DISABLE ROW LEVEL SECURITY;
+ALTER TABLE extracted_features DISABLE ROW LEVEL SECURITY;
+ALTER TABLE reddit_users DISABLE ROW LEVEL SECURITY;
+ALTER TABLE platform_config DISABLE ROW LEVEL SECURITY;
+
+GRANT SELECT ON mv_experiences_denormalized TO anon;
+GRANT SELECT ON mv_experiences_denormalized TO authenticated;

--- a/apps/shared/migrations/032_enable_rls.up.sql
+++ b/apps/shared/migrations/032_enable_rls.up.sql
@@ -1,0 +1,25 @@
+-- Enable RLS on all base tables
+-- With no anon/authenticated policies, the anon key cannot access these tables directly
+ALTER TABLE reddit_posts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE reddit_comments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE extracted_features ENABLE ROW LEVEL SECURITY;
+ALTER TABLE reddit_users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE platform_config ENABLE ROW LEVEL SECURITY;
+
+-- Explicit service_role full-access policies (belt-and-suspenders:
+-- service_role already bypasses RLS in Supabase by default, but being explicit is safer)
+CREATE POLICY "reddit_posts_service_role_all" ON reddit_posts
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+CREATE POLICY "reddit_comments_service_role_all" ON reddit_comments
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+CREATE POLICY "extracted_features_service_role_all" ON extracted_features
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+CREATE POLICY "reddit_users_service_role_all" ON reddit_users
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+CREATE POLICY "platform_config_service_role_all" ON platform_config
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+
+-- Materialized views cannot have RLS — block anon access via REVOKE
+-- The API service (service role) retains access
+REVOKE SELECT ON mv_experiences_denormalized FROM anon;
+REVOKE SELECT ON mv_experiences_denormalized FROM authenticated;

--- a/apps/user-extraction/api.py
+++ b/apps/user-extraction/api.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Optional
 from datetime import datetime
 
-from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi import FastAPI, HTTPException, BackgroundTasks, Depends, Header
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -60,6 +60,15 @@ async def shutdown_event():
     logger.info("=" * 80)
 
 
+async def verify_internal_api_key(x_internal_api_key: Optional[str] = Header(None)) -> None:
+    expected = os.getenv("INTERNAL_API_KEY")
+    if not expected:
+        print("[Auth] WARNING: INTERNAL_API_KEY not configured - skipping validation")
+        return
+    if not x_internal_api_key or x_internal_api_key != expected:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+
 # Request/Response models
 class AnalyzeRequest(BaseModel):
     limit: Optional[int] = 10
@@ -90,7 +99,7 @@ async def health_check():
     }
 
 
-@app.get("/api/stats", response_model=StatsResponse)
+@app.get("/api/stats", response_model=StatsResponse, dependencies=[Depends(verify_internal_api_key)])
 async def get_stats():
     """Get statistics about analyzed vs unanalyzed users."""
     try:
@@ -126,7 +135,7 @@ async def get_stats():
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.post("/api/analyze", response_model=AnalyzeResponse)
+@app.post("/api/analyze", response_model=AnalyzeResponse, dependencies=[Depends(verify_internal_api_key)])
 async def trigger_analysis(
     request: AnalyzeRequest,
     background_tasks: BackgroundTasks
@@ -199,7 +208,7 @@ async def trigger_analysis(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.get("/api/status")
+@app.get("/api/status", dependencies=[Depends(verify_internal_api_key)])
 async def get_status():
     """Get current analysis status."""
     return {

--- a/scripts/cron/post-extraction-cron.ts
+++ b/scripts/cron/post-extraction-cron.ts
@@ -26,6 +26,7 @@ const extractPosts = async () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "x-internal-api-key": process.env.INTERNAL_API_KEY ?? "",
       },
     });
 

--- a/scripts/cron/post-ingestion-cron.ts
+++ b/scripts/cron/post-ingestion-cron.ts
@@ -31,6 +31,7 @@ const ingestPosts = async () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "x-internal-api-key": process.env.INTERNAL_API_KEY ?? "",
       },
       body: JSON.stringify({
         all_tiers: true,

--- a/scripts/cron/user-extraction-cron.ts
+++ b/scripts/cron/user-extraction-cron.ts
@@ -28,6 +28,7 @@ const analyzeUsers = async () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "x-internal-api-key": process.env.INTERNAL_API_KEY ?? "",
       },
       body: JSON.stringify({
         limit: 10,


### PR DESCRIPTION
## Summary
- Enable Supabase RLS on all base tables — anon key can no longer read/write directly; only service_role (used by all backend services) has access
- Add `x-internal-api-key` auth to all pipeline HTTP endpoints (`/api/ingest`, `/api/extract`, `/api/analyze`, `/api/recommendations`, `/api/cache/clear`, `/api/status`, `/api/stats`) — unauthenticated requests return `403 Forbidden`
- Switch API service and rec-engine from `SUPABASE_ANON_KEY` → `SUPABASE_SERVICE_KEY` so they retain DB access after RLS

## Deploy order (critical — run migration last)
1. Set `SUPABASE_SERVICE_KEY` on API service in Railway env
2. Set `INTERNAL_API_KEY` (same value, `openssl rand -hex 32`) on all services + cron scripts in Railway
3. Merge + deploy (Railway auto-deploys)
4. Verify tRPC API is healthy in Railway logs
5. Run migration: `python3 apps/shared/migrations/run_migration.py apps/shared/migrations/032_enable_rls.up.sql`

## Test plan
- [ ] `GET /health` returns 200 without auth header (Railway health checks unaffected)
- [ ] `POST /api/ingest` without key → `403 Forbidden`
- [ ] `POST /api/ingest` with correct `x-internal-api-key` → `200 {"status": "started"}`
- [ ] `GET https://api.whichglp.com/trpc/experiences.list` still returns data (public tRPC unaffected)
- [ ] Supabase direct REST with anon key returns empty `[]` after migration
- [ ] Recommendation form on frontend returns results end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)