### PR TITLE
Aggressive prefetching, OpenAI prompt caching, and Railway nixpacks fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,27 @@ WhichGLP is a GLP-1 weight-loss drug comparison platform that aggregates real-wo
 - **Least privilege (tightest scope)**: always keep security to the tightest (minimal scope) possible that still accomplishes all our goals. Grant exactly the access needed and nothing more. This applies to Supabase RLS/policies, GRANTs, and roles, as well as to code (API surface, permissions, env access, etc.).
 - **Fail-closed, not fail-open**: when an error or uncertainty occurs, the default must be to **block** access rather than grant it. Never let a failure path fall through to allowing an action; on any error, deny.
 
+## Tools, CLIs & MCP Servers (Be Liberal)
+
+Be liberal with calling tools, CLI commands, and MCP servers to make changes and to diagnose and solve problems — particularly when diagnosing build or deploy failures.
+
+- **Reach for the platform's MCP server / CLI.** This repo uses **Railway** (backend services + Redis), **Vercel** (frontend), and **Supabase** (PostgreSQL) — install and use their MCP servers/CLIs (and analogously for Figma, Framer, AWS, GCP, Azure, Datadog, etc. if they come into play).
+- **Destructive actions still require approval.** Be liberal with read-only, diagnostic, and safely reversible actions — but always ask for the user's approval before executing destructive actions (deletes, rollbacks, production config/env changes, force operations, etc.).
+- **Suggest `/goal` for goal-driven runs.** When a task should run until done (e.g., fully fixing a deploy failure), suggest that the user can give the `/goal` slash-command to command you to keep working until the goal is reached.
+
+## LLM Calls (Prompt Caching & Observability)
+
+### Aggressive Prompt Caching
+
+For **all LLM calls, regardless of provider**, as long as the provider offers prompt caching, always be looking for opportunities to implement aggressive prompt caching — it dramatically cuts cost and latency. In this repo that especially means the **GPT-5-nano extraction services** (`apps/post-extraction`, `apps/user-extraction`): structure prompts so the static parts (system prompt, extraction instructions, schemas, few-shot examples) form a byte-stable prefix and the volatile parts (the Reddit post/comment being extracted) come last. OpenAI caches automatically for prompts ≥1024 tokens, but only if the prefix is byte-identical across requests — never interpolate timestamps/IDs into the static prefix, and verify hits via `usage.prompt_tokens_details.cached_tokens`. Provider caching APIs and best practices evolve — search the internet for the provider's current prompt-caching docs when implementing or reviewing.
+
+### Langfuse (Tracing Yes, Prompts No)
+
+If this repo adopts Langfuse, then:
+
+- **All LLM calls must be recorded through Langfuse tracing and sessions**, so cost, latency, and behavior are observable per conversation/run.
+- **Do not store LLM prompts in Langfuse** (no prompt management / `getPrompt()`). Prompts live **in the codebase** (e.g. `apps/post-extraction/prompts.py`, `apps/user-extraction/prompts.py`) as the single source of truth — version-controlled with the code that uses them, and easily readable as context by terminal agents like Claude Code.
+
 ## Documentation Structure
 
 This project uses multiple documentation files located in the `docs/` directory:
@@ -273,7 +294,7 @@ pytest scripts/legacy-ingestion/tests/test_parser.py  # Single test file
 
 ## Frontend (Next.js)
 
-The frontend is a Next.js 15 app with React 19, Tailwind CSS, and Radix UI components. It's not yet actively developed.
+The frontend is a Next.js 16 app with React 19, Tailwind CSS, and Radix UI components.
 
 ```bash
 cd apps/frontend
@@ -283,11 +304,24 @@ npm run lint     # Run ESLint
 ```
 
 **Tech Stack**:
-- Next.js 15 (App Router)
+- Next.js 16 (App Router)
 - TypeScript (strict mode)
 - Tailwind CSS v4
 - Radix UI + shadcn/ui components
 - React Hook Form + Zod for forms
+
+### Aggressive Prefetching (Pages & Queries)
+
+Prefetch aggressively so navigation feels instant — regardless of the size of the app (e.g. the number of pages). "Prefetch" always means **both** the frontend (route/components/bundle) **and** warming the underlying data queries — prefetching the UI shell without its data is only half the job. All prefetching must be background, deferred, and non-blocking: it must never delay or compete with rendering the page the user is actually on.
+
+- **Top-level pages**: when the user lands on any top-level page, prefetch all the other top-level pages.
+- **Tabs**: when the user lands on a top-level page that has tabs, prefetch all the other tabs of that page.
+- **Table rows (hover intent)**: on a page/tab with a table, if the user hovers over a row for more than 200ms, prefetch the result of clicking that row.
+- **Paginated tables**: when the user is on one page of a paginated table, prefetch the contents and queries of the next and previous pages.
+
+### Loading Indicators (When Loading Is Unavoidable)
+
+When a user action (clicking a button, etc.) triggers loading, show a small loading dialog only if the loading takes more than 200ms — never instantly. Do **not** accompany the loading dialog with a scrim/backdrop: the scrim causes a flash, and that flash is bad UI.
 
 ## Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 ### Frontend Service
 
-- **Framework:** Next.js 15 (App Router)
+- **Framework:** Next.js 16 (App Router)
 - **Language:** TypeScript (strict mode)
 - **UI:** React 19, Tailwind CSS v4, Radix UI + shadcn/ui
 - **API Client:** tRPC client, TanStack Query
@@ -46,7 +46,7 @@
 ### Backend Services
 
 **1. API Service** (`apps/api`)
-- **Runtime:** Node.js 20+
+- **Runtime:** Node.js 22+
 - **Language:** TypeScript (strict mode)
 - **Framework:** tRPC (type-safe API)
 - **Database:** Supabase client
@@ -96,6 +96,7 @@
 ### Development
 
 - **Python:** 3.13 with shared venv at repository root
-- **Node.js:** 20+ for frontend and API service
+- **Node.js:** 22+ for frontend and API service (`.nvmrc` pins 24)
 - **Monorepo:** All services in `apps/` directory
+- **Deploy config:** Python services on Railway build from the monorepo root via `apps/<service>/railway.json` (config-as-code), which references `apps/<service>/nixpacks.toml` through `nixpacksConfigPath`
 

--- a/apps/frontend/app/experiences/page.tsx
+++ b/apps/frontend/app/experiences/page.tsx
@@ -23,14 +23,16 @@ import { trpc } from "@/lib/trpc"
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Skeleton } from "@/components/ui/skeleton"
+import { LoadingDialog } from "@/components/ui/loading-dialog"
 import { RedditLink } from "@/components/reddit-link"
 import { getRedditReference, formatDuration, formatCost, getRatingColor, getSideEffectColor, sortSideEffects } from "@/lib/types"
-import { SortField, SortDirection, SORT_FIELD_LABELS, SORT_DIRECTION_TOOLTIPS, SortFieldType, SortDirectionType } from "@/lib/sort-types"
+import { SortField, SortDirection, SORT_FIELD_LABELS, SORT_DIRECTION_TOOLTIPS, type SortFieldType, type SortDirectionType } from "@/lib/sort-types"
+import { buildExperiencesListInput, INFINITE_SCROLL_PREFETCH_ROOT_MARGIN } from "@/lib/prefetch"
+import { useHoverPrefetch } from "@/hooks/use-hover-prefetch"
 
 const ExperiencesPage = () => {
   const searchParams = useSearchParams()
@@ -80,13 +82,13 @@ const ExperiencesPage = () => {
     isLoading: experiencesLoading,
     isFetching,
   } = trpc.experiences.list.useInfiniteQuery(
-    {
+    // Built through the shared helper so prefetchers hit the same cache key
+    buildExperiencesListInput({
       drug: selectedDrug !== "all" ? selectedDrug : undefined,
       search: debouncedSearchText || undefined,
       sortBy,
       sortOrder,
-      limit: 20,
-    },
+    }),
     {
       getNextPageParam: (lastPage: any, allPages: any[]) => {
         const loadedCount = allPages.reduce((sum: number, page: any) => sum + page.experiences.length, 0)
@@ -105,6 +107,12 @@ const ExperiencesPage = () => {
 
   // Fetch drug stats for the filter dropdown
   const { data: drugs } = trpc.drugs.getAllStats.useQuery()
+
+  // Hover intent (>200ms) on a card prefetches the detail it would open
+  const utils = trpc.useUtils()
+  const getHoverPrefetchProps = useHoverPrefetch((id: string) => {
+    void utils.experiences.getById.prefetch({ id })
+  })
 
   // Fetch selected experience details
   const { data: selectedExperience, isLoading: isLoadingExperience } = trpc.experiences.getById.useQuery(
@@ -131,13 +139,15 @@ const ExperiencesPage = () => {
           fetchNextPage()
         }
       },
-      { threshold: 0.1 }
+      // Large rootMargin prefetches the next page well before the user
+      // reaches the bottom, so scrolling never waits on the network
+      { threshold: 0.1, rootMargin: INFINITE_SCROLL_PREFETCH_ROOT_MARGIN }
     )
 
     observer.observe(loadMoreRef.current)
 
     return () => observer.disconnect()
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage, data])
 
   // Determine if we should show skeleton (initial load only, not filter changes)
   const showSkeleton = experiencesLoading && !data
@@ -284,15 +294,11 @@ const ExperiencesPage = () => {
           </Card>
         ) : (
           <div className="relative">
-            {/* Show loading overlay when filtering */}
-            {isFetching && !isFetchingNextPage && (
-              <div className="absolute inset-0 bg-background/50 backdrop-blur-sm z-10 flex items-center justify-center">
-                <div className="flex items-center gap-2 bg-card border border-border px-4 py-2 rounded-lg shadow-lg">
-                  <Loader2 className="h-4 w-4 animate-spin text-primary" />
-                  <span className="text-sm">Updating results...</span>
-                </div>
-              </div>
-            )}
+            {/* Loading dialog (no scrim) when filtering takes >200ms */}
+            <LoadingDialog
+              isOpen={isFetching && !isFetchingNextPage}
+              message="Updating results…"
+            />
 
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
               {experiencesData.experiences.map((experience: any, index: number) => (
@@ -303,6 +309,7 @@ const ExperiencesPage = () => {
                     posthog.capture('experience_card_clicked', { experience_id: experience.id, drug: experience.primary_drug })
                     setSelectedExperienceId(experience.id)
                   }}
+                  {...getHoverPrefetchProps(experience.id)}
                 />
               ))}
             </div>

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -6,6 +6,7 @@ import { Analytics as VercelAnalytics } from "@vercel/analytics/next";
 import { Suspense } from "react";
 import { Providers } from "@/components/providers";
 import { Analytics } from "@/components/analytics";
+import { AppPrefetcher } from "@/components/app-prefetcher";
 import "./globals.css";
 
 // Configure fonts with display: swap for better performance
@@ -170,6 +171,7 @@ const RootLayout = ({
             {/* <Scrim>{children}</Scrim> */}
             {children}
             <Analytics />
+            <AppPrefetcher />
           </Suspense>
           <VercelAnalytics />
         </Providers>

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 
 import posthog from 'posthog-js';
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Navigation } from "@/components/navigation";
 import { Footer } from "@/components/footer";
 import { DrugComparison } from "@/components/drug-comparison";
@@ -25,28 +22,10 @@ import {
 } from "@/components/ui/popover";
 
 const HomePage = () => {
-  const router = useRouter();
-
-  // Prefetch related pages during idle time to avoid impacting page performance
-  useEffect(() => {
-    if (typeof window !== "undefined" && "requestIdleCallback" in window) {
-      requestIdleCallback(() => {
-        router.prefetch("/experiences");
-        router.prefetch("/recommendations");
-        router.prefetch("/about");
-      });
-    } else {
-      // Fallback for browsers without requestIdleCallback
-      setTimeout(() => {
-        router.prefetch("/experiences");
-        router.prefetch("/recommendations");
-        router.prefetch("/about");
-      }, 1000);
-    }
-  }, [router]);
+  // Page and query prefetching is handled globally by AppPrefetcher in the root layout
 
   // Fetch real platform stats from backend
-  const { data: stats, isLoading } = trpc.platform.getStats.useQuery();
+  const { data: stats } = trpc.platform.getStats.useQuery();
   return (
     <div className="min-h-screen">
       <Navigation />

--- a/apps/frontend/app/recommendations/page.tsx
+++ b/apps/frontend/app/recommendations/page.tsx
@@ -28,11 +28,15 @@ import {
   Users,
   Target,
 } from "lucide-react";
-import { PredictionInput, PredictionResult, Sex } from "@/lib/types";
+import type { PredictionInput, PredictionResult, Sex } from "@/lib/types";
 import { trpc } from "@/lib/trpc";
+import { LoadingDialog } from "@/components/ui/loading-dialog";
+import { useHoverPrefetch } from "@/hooks/use-hover-prefetch";
+import { usePrefetchExperiences } from "@/hooks/use-prefetch-experiences";
 
 const RecommendationsPage = () => {
   const router = useRouter();
+  const prefetchExperiences = usePrefetchExperiences();
   const [formData, setFormData] = useState<Partial<PredictionInput>>({
     weightUnit: "lbs",
     country: "USA",
@@ -169,9 +173,21 @@ const RecommendationsPage = () => {
     router.push(`/experiences?${params.toString()}`);
   };
 
+  // Hover intent (>200ms) on a result card prefetches the experiences page
+  // (route + query) it would navigate to
+  const getRecommendationHoverPrefetchProps = useHoverPrefetch((drug: string) =>
+    prefetchExperiences({ drug, search: formData.comorbidities?.[0] })
+  );
+
   return (
     <div className="min-h-screen relative">
       <Navigation />
+
+      {/* Loading dialog (no scrim) while recommendations are computed */}
+      <LoadingDialog
+        isOpen={getRecommendationsMutation.isPending}
+        message="Analyzing your profile…"
+      />
 
       <div className="container mx-auto px-4 pt-24 pb-12">
         <div className="mb-8">
@@ -479,6 +495,7 @@ const RecommendationsPage = () => {
                     index === 0 ? "ring-2 ring-primary" : ""
                   }`}
                   onClick={() => handleRecommendationClick(recommendation.drug, recommendation.matchScore, index + 1)}
+                  {...getRecommendationHoverPrefetchProps(recommendation.drug)}
                 >
                   {index === 0 && (
                     <Badge className="absolute -top-3 left-1/2 -translate-x-1/2">

--- a/apps/frontend/biome.json
+++ b/apps/frontend/biome.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["**", "!node_modules", "!.next", "!next-env.d.ts"]
+  },
+  "formatter": {
+    "enabled": false
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "assist": {
+    "enabled": false
+  }
+}

--- a/apps/frontend/components/app-prefetcher.tsx
+++ b/apps/frontend/components/app-prefetcher.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useEffect } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+import { trpc } from '@/lib/trpc'
+import { buildExperiencesListInput, runWhenIdle } from '@/lib/prefetch'
+
+const topLevelRoutes = [
+  '/',
+  '/experiences',
+  '/recommendations',
+  '/dashboard',
+  '/about',
+  '/privacy',
+  '/terms',
+] as const
+
+/**
+ * Mounted once in the root layout. Whenever the user lands on any page, it
+ * prefetches every other top-level page — both the route bundle and the
+ * underlying tRPC queries (which also covers every dashboard tab, since the
+ * dashboard fetches all of its tabs' queries up front). Everything runs
+ * during browser idle time so it never competes with the current page, and
+ * the QueryClient's staleTime makes repeat prefetches free.
+ */
+export const AppPrefetcher = () => {
+  const pathname = usePathname()
+  const router = useRouter()
+  const utils = trpc.useUtils()
+
+  useEffect(() => {
+    runWhenIdle(() => {
+      // Frontend: route bundles for all other top-level pages
+      for (const route of topLevelRoutes) {
+        if (route !== pathname) router.prefetch(route)
+      }
+
+      // Data: warm the queries behind every top-level page and tab
+      void utils.platform.getStats.prefetch() // home + dashboard
+      void utils.drugs.getAllStats.prefetch() // home comparison tabs + experiences filter + dashboard
+      void utils.experiences.list.prefetchInfinite(buildExperiencesListInput()) // experiences default view
+      void utils.locations.getData.prefetch() // dashboard "Cost by Location" tab
+      void utils.demographics.getData.prefetch() // dashboard "Demographics" tab
+      void utils.platform.getTrends.prefetch({ period: 'month' }) // dashboard "Trends" tab
+    })
+  }, [pathname, router, utils])
+
+  return null
+}

--- a/apps/frontend/components/drug-comparison.tsx
+++ b/apps/frontend/components/drug-comparison.tsx
@@ -5,7 +5,6 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Tooltip,
@@ -18,14 +17,17 @@ import {
   TrendingDown,
   DollarSign,
   AlertCircle,
-  Users,
   Info,
   Loader2,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc";
+import { runWhenIdle } from "@/lib/prefetch";
+import { useHoverPrefetch } from "@/hooks/use-hover-prefetch";
+import { usePrefetchExperiences } from "@/hooks/use-prefetch-experiences";
 
 export const DrugComparison = () => {
   const router = useRouter();
+  const prefetchExperiences = usePrefetchExperiences();
 
   // Fetch real drug stats from API
   const { data: drugStats, isLoading, isError, error } = trpc.drugs.getAllStats.useQuery();
@@ -47,25 +49,22 @@ export const DrugComparison = () => {
     }
   }, [drugStats, selectedMeds.length]);
 
-  // Prefetch experiences pages for selected drugs during idle time
+  // Prefetch the experiences route AND warm its list query for the selected
+  // drugs during idle time, so clicking a card lands on a fully-loaded page
   useEffect(() => {
     if (selectedMeds.length === 0) return;
 
-    if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
-      requestIdleCallback(() => {
-        selectedMeds.forEach((drug) => {
-          router.prefetch(`/experiences?drug=${encodeURIComponent(drug)}`);
-        });
-      });
-    } else {
-      // Fallback for browsers without requestIdleCallback
-      setTimeout(() => {
-        selectedMeds.forEach((drug) => {
-          router.prefetch(`/experiences?drug=${encodeURIComponent(drug)}`);
-        });
-      }, 500);
-    }
-  }, [selectedMeds, router]);
+    runWhenIdle(() => {
+      for (const drug of selectedMeds) {
+        prefetchExperiences({ drug });
+      }
+    });
+  }, [selectedMeds, prefetchExperiences]);
+
+  // Hover intent (>200ms) on a drug card prefetches its experiences page
+  const getDrugHoverPrefetchProps = useHoverPrefetch((drug: string) =>
+    prefetchExperiences({ drug })
+  );
 
   const toggleDrug = (drug: string) => {
     if (selectedMeds.includes(drug)) {
@@ -187,6 +186,7 @@ export const DrugComparison = () => {
                 key={med.drug}
                 className="border-border/40 bg-card p-6 cursor-pointer transition-all hover:shadow-lg hover:border-primary/50"
                 onClick={() => handleDrugClick(med.drug)}
+                {...getDrugHoverPrefetchProps(med.drug)}
               >
                 <div className="mb-4">
                   <h3 className="text-xl font-bold">{med.drug}</h3>
@@ -323,6 +323,7 @@ export const DrugComparison = () => {
                 key={med.drug}
                 className="border-border/40 bg-card p-6 cursor-pointer transition-all hover:shadow-lg hover:border-primary/50"
                 onClick={() => handleDrugClick(med.drug)}
+                {...getDrugHoverPrefetchProps(med.drug)}
               >
                 <h3 className="mb-4 text-xl font-bold">{med.drug}</h3>
 
@@ -433,6 +434,7 @@ export const DrugComparison = () => {
                   key={med.drug}
                   className="border-border/40 bg-card p-6 cursor-pointer transition-all hover:shadow-lg hover:border-primary/50"
                   onClick={() => handleDrugClick(med.drug)}
+                  {...getDrugHoverPrefetchProps(med.drug)}
                 >
                   <h3 className="mb-4 text-xl font-bold">{med.drug}</h3>
 

--- a/apps/frontend/components/experience-card.tsx
+++ b/apps/frontend/components/experience-card.tsx
@@ -2,10 +2,9 @@ import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { RedditLink } from "@/components/reddit-link"
 import {
-  ExperienceCard as ExperienceCardType,
+  type ExperienceCard as ExperienceCardType,
   getRedditReference,
   formatDuration,
-  formatCost,
   getRatingColor,
   getSideEffectColor,
   sortSideEffects,
@@ -15,13 +14,16 @@ import { TrendingDown, Clock, AlertCircle, Star } from "lucide-react"
 type ExperienceCardProps = {
   experience: ExperienceCardType
   onClick?: () => void
+  // Hover handlers let the parent prefetch the detail view on hover intent
+  onMouseEnter?: () => void
+  onMouseLeave?: () => void
 }
 
 /**
  * Card displaying a single user experience
  * Used on /experiences page and in search results
  */
-export function ExperienceCard({ experience, onClick }: ExperienceCardProps) {
+export function ExperienceCard({ experience, onClick, onMouseEnter, onMouseLeave }: ExperienceCardProps) {
   const redditRef = getRedditReference(experience)
 
   // Calculate weight loss display with percentage
@@ -54,6 +56,8 @@ export function ExperienceCard({ experience, onClick }: ExperienceCardProps) {
     <Card
       className="border-border/40 bg-card p-6 hover:border-primary/50 transition-colors cursor-pointer relative"
       onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <div className="space-y-4">
         {/* Header */}

--- a/apps/frontend/components/ui/loading-dialog.tsx
+++ b/apps/frontend/components/ui/loading-dialog.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { Spinner } from '@/components/ui/spinner'
+import { useDelayedVisible, LOADING_INDICATOR_DELAY_MS } from '@/hooks/use-delayed-visible'
+import { cn } from '@/lib/utils'
+
+type LoadingDialogProps = {
+  isOpen: boolean
+  message?: string
+  /** How long the load must run before the dialog appears (avoids flashes). */
+  delayMs?: number
+  className?: string
+}
+
+/**
+ * Small floating loading dialog for button-triggered loads that exceed
+ * `delayMs` (default 200ms). Deliberately rendered WITHOUT a scrim/backdrop:
+ * a scrim flashing in and out on short loads is worse UI than no indicator,
+ * and the page behind stays interactive.
+ */
+export const LoadingDialog = ({
+  isOpen,
+  message = 'Loading…',
+  delayMs = LOADING_INDICATOR_DELAY_MS,
+  className,
+}: LoadingDialogProps) => {
+  const isVisible = useDelayedVisible(isOpen, delayMs)
+
+  if (!isVisible) return null
+
+  return (
+    <div
+      data-slot="loading-dialog"
+      role="status"
+      aria-live="polite"
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 flex -translate-x-1/2 -translate-y-1/2 items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 shadow-lg',
+        className
+      )}
+    >
+      <Spinner aria-hidden="true" className="text-primary" />
+      <span className="text-sm text-card-foreground">{message}</span>
+    </div>
+  )
+}

--- a/apps/frontend/hooks/use-delayed-visible.test.ts
+++ b/apps/frontend/hooks/use-delayed-visible.test.ts
@@ -1,0 +1,84 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { LOADING_INDICATOR_DELAY_MS, useDelayedVisible } from './use-delayed-visible'
+
+describe('useDelayedVisible', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('stays hidden while inactive', () => {
+    const { result } = renderHook(() => useDelayedVisible(false))
+    expect(result.current).toBe(false)
+    act(() => vi.advanceTimersByTime(10_000))
+    expect(result.current).toBe(false)
+  })
+
+  it('does not appear before the delay elapses', () => {
+    const { result } = renderHook(() => useDelayedVisible(true))
+    act(() => vi.advanceTimersByTime(LOADING_INDICATOR_DELAY_MS - 1))
+    expect(result.current).toBe(false)
+  })
+
+  it('appears once the delay elapses', () => {
+    const { result } = renderHook(() => useDelayedVisible(true))
+    act(() => vi.advanceTimersByTime(LOADING_INDICATOR_DELAY_MS))
+    expect(result.current).toBe(true)
+  })
+
+  it('never appears when the load finishes before the delay', () => {
+    const { result, rerender } = renderHook(
+      ({ isActive }) => useDelayedVisible(isActive),
+      { initialProps: { isActive: true } }
+    )
+    act(() => vi.advanceTimersByTime(LOADING_INDICATOR_DELAY_MS - 50))
+    rerender({ isActive: false })
+    act(() => vi.advanceTimersByTime(10_000))
+    expect(result.current).toBe(false)
+  })
+
+  it('resets immediately when deactivated after becoming visible', () => {
+    const { result, rerender } = renderHook(
+      ({ isActive }) => useDelayedVisible(isActive),
+      { initialProps: { isActive: true } }
+    )
+    act(() => vi.advanceTimersByTime(LOADING_INDICATOR_DELAY_MS))
+    expect(result.current).toBe(true)
+    rerender({ isActive: false })
+    expect(result.current).toBe(false)
+  })
+
+  it('honors a custom delay', () => {
+    const { result } = renderHook(() => useDelayedVisible(true, 500))
+    act(() => vi.advanceTimersByTime(499))
+    expect(result.current).toBe(false)
+    act(() => vi.advanceTimersByTime(1))
+    expect(result.current).toBe(true)
+  })
+
+  it('restarts the delay on each new activation', () => {
+    const { result, rerender } = renderHook(
+      ({ isActive }) => useDelayedVisible(isActive),
+      { initialProps: { isActive: true } }
+    )
+    act(() => vi.advanceTimersByTime(LOADING_INDICATOR_DELAY_MS - 1))
+    rerender({ isActive: false })
+    rerender({ isActive: true })
+    act(() => vi.advanceTimersByTime(LOADING_INDICATOR_DELAY_MS - 1))
+    expect(result.current).toBe(false)
+    act(() => vi.advanceTimersByTime(1))
+    expect(result.current).toBe(true)
+  })
+
+  it('cleans up its timer on unmount without firing', () => {
+    const { unmount } = renderHook(() => useDelayedVisible(true))
+    unmount()
+    // Advancing past the delay after unmount must not warn or throw
+    act(() => vi.advanceTimersByTime(10_000))
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/apps/frontend/hooks/use-delayed-visible.ts
+++ b/apps/frontend/hooks/use-delayed-visible.ts
@@ -1,0 +1,29 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+
+/** How long a load must run before loading UI may appear (avoids flashes). */
+export const LOADING_INDICATOR_DELAY_MS = 200
+
+/**
+ * Returns true only after `isActive` has been true for `delayMs`, so loading
+ * UI never flashes for fast operations. Resets immediately when `isActive`
+ * goes false.
+ */
+export const useDelayedVisible = (
+  isActive: boolean,
+  delayMs = LOADING_INDICATOR_DELAY_MS
+): boolean => {
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    if (!isActive) {
+      setIsVisible(false)
+      return
+    }
+    const timer = setTimeout(() => setIsVisible(true), delayMs)
+    return () => clearTimeout(timer)
+  }, [isActive, delayMs])
+
+  return isVisible
+}

--- a/apps/frontend/hooks/use-hover-prefetch.test.ts
+++ b/apps/frontend/hooks/use-hover-prefetch.test.ts
@@ -1,0 +1,101 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { HOVER_INTENT_DELAY_MS } from '@/lib/prefetch'
+import { useHoverPrefetch } from './use-hover-prefetch'
+
+describe('useHoverPrefetch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fires after the pointer rests for the delay', () => {
+    const onHoverIntent = vi.fn()
+    const { result } = renderHook(() => useHoverPrefetch(onHoverIntent))
+
+    result.current('row-1').onMouseEnter()
+    vi.advanceTimersByTime(HOVER_INTENT_DELAY_MS - 1)
+    expect(onHoverIntent).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onHoverIntent).toHaveBeenCalledExactlyOnceWith('row-1')
+  })
+
+  it('does not fire when the pointer leaves before the delay', () => {
+    const onHoverIntent = vi.fn()
+    const { result } = renderHook(() => useHoverPrefetch(onHoverIntent))
+
+    const props = result.current('row-1')
+    props.onMouseEnter()
+    vi.advanceTimersByTime(HOVER_INTENT_DELAY_MS - 1)
+    props.onMouseLeave()
+    vi.advanceTimersByTime(10_000)
+    expect(onHoverIntent).not.toHaveBeenCalled()
+  })
+
+  it('a quick sweep across rows fires only for the row the pointer rests on', () => {
+    const onHoverIntent = vi.fn()
+    const { result } = renderHook(() => useHoverPrefetch(onHoverIntent))
+
+    const row1 = result.current('row-1')
+    const row2 = result.current('row-2')
+    row1.onMouseEnter()
+    vi.advanceTimersByTime(50)
+    row1.onMouseLeave()
+    row2.onMouseEnter()
+    vi.advanceTimersByTime(HOVER_INTENT_DELAY_MS)
+    expect(onHoverIntent).toHaveBeenCalledExactlyOnceWith('row-2')
+  })
+
+  it('re-entering the same row restarts the timer', () => {
+    const onHoverIntent = vi.fn()
+    const { result } = renderHook(() => useHoverPrefetch(onHoverIntent))
+
+    const props = result.current('row-1')
+    props.onMouseEnter()
+    vi.advanceTimersByTime(HOVER_INTENT_DELAY_MS - 1)
+    props.onMouseEnter() // re-enter without leave (e.g. child element churn)
+    vi.advanceTimersByTime(HOVER_INTENT_DELAY_MS - 1)
+    expect(onHoverIntent).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onHoverIntent).toHaveBeenCalledOnce()
+  })
+
+  it('honors a custom delay', () => {
+    const onHoverIntent = vi.fn()
+    const { result } = renderHook(() => useHoverPrefetch(onHoverIntent, 500))
+
+    result.current('row-1').onMouseEnter()
+    vi.advanceTimersByTime(499)
+    expect(onHoverIntent).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onHoverIntent).toHaveBeenCalledOnce()
+  })
+
+  it('always calls the latest callback (no stale closures)', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ callback }) => useHoverPrefetch(callback),
+      { initialProps: { callback: first } }
+    )
+
+    result.current('row-1').onMouseEnter()
+    rerender({ callback: second })
+    vi.advanceTimersByTime(HOVER_INTENT_DELAY_MS)
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledExactlyOnceWith('row-1')
+  })
+
+  it('clears a pending timer on unmount', () => {
+    const onHoverIntent = vi.fn()
+    const { result, unmount } = renderHook(() => useHoverPrefetch(onHoverIntent))
+
+    result.current('row-1').onMouseEnter()
+    unmount()
+    vi.advanceTimersByTime(10_000)
+    expect(onHoverIntent).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/hooks/use-hover-prefetch.ts
+++ b/apps/frontend/hooks/use-hover-prefetch.ts
@@ -1,0 +1,48 @@
+"use client"
+
+import { useEffect, useRef } from 'react'
+import { HOVER_INTENT_DELAY_MS } from '@/lib/prefetch'
+
+/**
+ * Hover-intent prefetching: fires `onHoverIntent(target)` once the pointer
+ * has rested on an element for `delayMs` (default 200ms), so quick sweeps
+ * across a list don't trigger a prefetch per row.
+ *
+ * Returns a props getter — spread the result onto each hoverable element:
+ *   const getHoverPrefetchProps = useHoverPrefetch((id: string) => prefetch(id))
+ *   <div {...getHoverPrefetchProps(row.id)}>…</div>
+ */
+export const useHoverPrefetch = <T,>(
+  onHoverIntent: (target: T) => void,
+  delayMs = HOVER_INTENT_DELAY_MS
+) => {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Latest-ref pattern: handlers always call the freshest callback without
+  // retriggering consumers; assigned in an effect to stay concurrent-safe.
+  const onHoverIntentRef = useRef(onHoverIntent)
+  useEffect(() => {
+    onHoverIntentRef.current = onHoverIntent
+  })
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  const getHoverPrefetchProps = (target: T) => ({
+    onMouseEnter: () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => onHoverIntentRef.current(target), delayMs)
+    },
+    onMouseLeave: () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    },
+  })
+
+  return getHoverPrefetchProps
+}

--- a/apps/frontend/hooks/use-prefetch-experiences.ts
+++ b/apps/frontend/hooks/use-prefetch-experiences.ts
@@ -1,0 +1,29 @@
+"use client"
+
+import { useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { trpc } from '@/lib/trpc'
+import { buildExperiencesListInput } from '@/lib/prefetch'
+
+/**
+ * Returns a stable callback that prefetches the /experiences page for a drug
+ * — both the route bundle and the warmed list query — so navigating there is
+ * instant. Shared by the drug-comparison cards and recommendation results.
+ */
+export const usePrefetchExperiences = () => {
+  const router = useRouter()
+  const utils = trpc.useUtils()
+
+  return useCallback(
+    ({ drug, search }: { drug: string; search?: string }) => {
+      const params = new URLSearchParams({ drug })
+      if (search) params.set('search', search)
+      router.prefetch(`/experiences?${params.toString()}`)
+      // `|| undefined` coerces '' too, matching the page's own input building
+      void utils.experiences.list.prefetchInfinite(
+        buildExperiencesListInput({ drug, search: search || undefined })
+      )
+    },
+    [router, utils]
+  )
+}

--- a/apps/frontend/lib/prefetch.test.ts
+++ b/apps/frontend/lib/prefetch.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildExperiencesListInput,
+  EXPERIENCES_PAGE_SIZE,
+  runWhenIdle,
+} from './prefetch'
+import { SortDirection, SortField } from './sort-types'
+
+describe('buildExperiencesListInput', () => {
+  it('returns the default input with no options', () => {
+    expect(buildExperiencesListInput()).toEqual({
+      drug: undefined,
+      search: undefined,
+      sortBy: SortField.DATE,
+      sortOrder: SortDirection.DESC,
+      limit: EXPERIENCES_PAGE_SIZE,
+    })
+  })
+
+  it('applies overrides while keeping the other defaults', () => {
+    expect(
+      buildExperiencesListInput({ drug: 'Ozempic', sortOrder: SortDirection.ASC })
+    ).toEqual({
+      drug: 'Ozempic',
+      search: undefined,
+      sortBy: SortField.DATE,
+      sortOrder: SortDirection.ASC,
+      limit: EXPERIENCES_PAGE_SIZE,
+    })
+  })
+
+  it('produces the same React Query hash whether optional keys are omitted or undefined', () => {
+    // React Query's hashKey is JSON.stringify-based, which drops undefined values —
+    // this is what makes prefetched inputs hit the same cache entry as page inputs.
+    const fromPrefetcher = buildExperiencesListInput()
+    const fromPageState = buildExperiencesListInput({ drug: undefined, search: undefined })
+    expect(JSON.stringify(fromPrefetcher)).toBe(JSON.stringify(fromPageState))
+  })
+
+  it('preserves empty-string search as given (callers must coerce "" themselves)', () => {
+    expect(buildExperiencesListInput({ search: '' }).search).toBe('')
+  })
+})
+
+describe('runWhenIdle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('uses requestIdleCallback when available', () => {
+    const requestIdleCallback = vi.fn((cb: IdleRequestCallback) => {
+      cb({} as IdleDeadline)
+      return 1
+    })
+    vi.stubGlobal('requestIdleCallback', requestIdleCallback)
+
+    const callback = vi.fn()
+    runWhenIdle(callback)
+
+    expect(requestIdleCallback).toHaveBeenCalledOnce()
+    expect(callback).toHaveBeenCalledOnce()
+  })
+
+  it('falls back to setTimeout when requestIdleCallback is missing', () => {
+    // jsdom (like Safari) has no requestIdleCallback
+    expect('requestIdleCallback' in window).toBe(false)
+
+    const callback = vi.fn()
+    runWhenIdle(callback, 500)
+
+    expect(callback).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(499)
+    expect(callback).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(callback).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/frontend/lib/prefetch.ts
+++ b/apps/frontend/lib/prefetch.ts
@@ -3,8 +3,8 @@ import { SortField, SortDirection, type SortFieldType, type SortDirectionType } 
 /**
  * Shared helpers for the app-wide aggressive-prefetching strategy:
  * whenever the user lands anywhere, all other top-level pages (and their
- * queries) are warmed in the background, plus hover-intent and
- * next/previous-page prefetching for lists.
+ * queries) are warmed in the background, plus hover-intent prefetching and
+ * early next-page fetching for infinite lists (previous pages stay cached).
  */
 
 export const EXPERIENCES_PAGE_SIZE = 20

--- a/apps/frontend/lib/prefetch.ts
+++ b/apps/frontend/lib/prefetch.ts
@@ -1,0 +1,61 @@
+import { SortField, SortDirection, type SortFieldType, type SortDirectionType } from './sort-types'
+
+/**
+ * Shared helpers for the app-wide aggressive-prefetching strategy:
+ * whenever the user lands anywhere, all other top-level pages (and their
+ * queries) are warmed in the background, plus hover-intent and
+ * next/previous-page prefetching for lists.
+ */
+
+export const EXPERIENCES_PAGE_SIZE = 20
+
+/** Pointer must rest this long on a row/card before its target is prefetched. */
+export const HOVER_INTENT_DELAY_MS = 200
+
+/** Fallback delay when requestIdleCallback is unavailable. */
+export const IDLE_PREFETCH_TIMEOUT_MS = 1000
+
+/** Distance before the list bottom at which the next page starts fetching. */
+export const INFINITE_SCROLL_PREFETCH_ROOT_MARGIN = '1000px 0px'
+
+export type ExperiencesListInput = {
+  drug?: string
+  search?: string
+  sortBy: SortFieldType
+  sortOrder: SortDirectionType
+  limit: number
+}
+
+/**
+ * Builds the input for `trpc.experiences.list`. The React Query cache key is
+ * derived from this object, so the /experiences page and every prefetcher
+ * must build it through this one function — any drift between them means the
+ * warmed cache entry is never read.
+ */
+export const buildExperiencesListInput = (options?: {
+  drug?: string
+  search?: string
+  sortBy?: SortFieldType
+  sortOrder?: SortDirectionType
+}): ExperiencesListInput => ({
+  drug: options?.drug,
+  search: options?.search,
+  sortBy: options?.sortBy ?? SortField.DATE,
+  sortOrder: options?.sortOrder ?? SortDirection.DESC,
+  limit: EXPERIENCES_PAGE_SIZE,
+})
+
+/**
+ * Runs `callback` when the browser is idle so prefetching never competes
+ * with rendering the page the user is actually on.
+ */
+export const runWhenIdle = (callback: () => void, timeoutMs = IDLE_PREFETCH_TIMEOUT_MS): void => {
+  if (typeof window === 'undefined') return
+
+  if ('requestIdleCallback' in window) {
+    requestIdleCallback(() => callback(), { timeout: timeoutMs })
+  } else {
+    // Fallback for browsers without requestIdleCallback (e.g. Safari)
+    setTimeout(callback, timeoutMs)
+  }
+}

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -57,7 +57,7 @@
         "posthog-js": "^1.383.1",
         "react": "^19.2.7",
         "react-day-picker": "10.0.1",
-        "react-dom": "^19",
+        "react-dom": "^19.2.7",
         "react-hook-form": "^7.78.0",
         "react-is": "^19.2.7",
         "react-resizable-panels": "^4.11.2",
@@ -70,14 +70,19 @@
         "zod": "4.4.3"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.16",
         "@tailwindcss/postcss": "^4.3.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^25",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "jsdom": "^29.1.1",
         "postcss": "^8.5",
         "tailwindcss": "^4.3.0",
         "tw-animate-css": "1.4.0",
-        "typescript": "^6"
+        "typescript": "^6",
+        "vitest": "^4.1.8"
       },
       "engines": {
         "node": ">=22"
@@ -96,20 +101,475 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@date-fns/tz": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
-      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
       "license": "MIT"
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.16.tgz",
+      "integrity": "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.16",
+        "@biomejs/cli-darwin-x64": "2.4.16",
+        "@biomejs/cli-linux-arm64": "2.4.16",
+        "@biomejs/cli-linux-arm64-musl": "2.4.16",
+        "@biomejs/cli-linux-x64": "2.4.16",
+        "@biomejs/cli-linux-x64-musl": "2.4.16",
+        "@biomejs/cli-win32-arm64": "2.4.16",
+        "@biomejs/cli-win32-x64": "2.4.16"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.16.tgz",
+      "integrity": "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.16.tgz",
+      "integrity": "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.16.tgz",
+      "integrity": "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.16.tgz",
+      "integrity": "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.16.tgz",
+      "integrity": "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.16.tgz",
+      "integrity": "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.16.tgz",
+      "integrity": "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.16.tgz",
+      "integrity": "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.3.tgz",
+      "integrity": "sha512-DOgvIPkikIOixQRlD4YF31VN6fLLUTdrzhfRbis8vm0kMTgIbEPX0Ip/YX9fOeV9iywAS4sUUbTclpan7yYP8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+      "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -163,9 +623,9 @@
       }
     },
     "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -255,6 +715,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -270,6 +733,9 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -287,6 +753,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -302,6 +771,9 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -319,6 +791,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -334,6 +809,9 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -351,6 +829,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -367,6 +848,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -382,6 +866,9 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -405,6 +892,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -426,6 +916,9 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -449,6 +942,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -470,6 +966,9 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -493,6 +992,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -515,6 +1017,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -536,6 +1041,9 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -678,16 +1186,35 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@next/env": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.7.tgz",
-      "integrity": "sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
+      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.7.tgz",
-      "integrity": "sha512-vm1EDI/pVaBNNiychmxk3fft+OhQPVD9cIM/tReLZIQ3TfQ4kqI9DwKk00dzuS1ulC7icbrzCFrmRRlk9PfNdw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
+      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
       "cpu": [
         "arm64"
       ],
@@ -701,9 +1228,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.7.tgz",
-      "integrity": "sha512-O3IRSv1ZBL1zs0WrIgefTEcTKFVn+ryxBNe54erJ6KsD+2f/Mmt7g2jOYh8PSBdUwPtKQJuCsTMlZ7tIu2AcsQ==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
+      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
       "cpu": [
         "x64"
       ],
@@ -717,9 +1244,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.7.tgz",
-      "integrity": "sha512-Re6PZtjBDd0aMU+VcZcC/PrIvj4WhrjDYtMhhCVQamWN4L90EVP0pcEOBQD25prSlw7OzNw5QpHLWMilRLsRNw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
+      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
       "cpu": [
         "arm64"
       ],
@@ -736,9 +1263,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.7.tgz",
-      "integrity": "sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
+      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
       ],
@@ -755,9 +1282,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.7.tgz",
-      "integrity": "sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
+      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
       "cpu": [
         "x64"
       ],
@@ -774,9 +1301,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.7.tgz",
-      "integrity": "sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
+      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
       ],
@@ -793,9 +1320,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.7.tgz",
-      "integrity": "sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
+      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
       "cpu": [
         "arm64"
       ],
@@ -809,9 +1336,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.7.tgz",
-      "integrity": "sha512-J4WlM72NMk076Qsg0jTdK3SNXatlSdnjW7L7oNGLst1tAGjHrJh/FYi+pw9wyIjEtGRKDNzD0zuiY16oWYWVaw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
+      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
       "cpu": [
         "x64"
       ],
@@ -824,19 +1351,29 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@posthog/core": {
-      "version": "1.30.12",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.30.12.tgz",
-      "integrity": "sha512-XKkiK5H8ww3RHmL+TzHHnWCdcmZzfTy5RuiIs8yx9ABzG5Gdn+FgK/cH9XSvh5xU6Avkk1b6zLG/hZfF2nZAyQ==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.32.3.tgz",
+      "integrity": "sha512-vwOEMfZvGv5XxNWV7p9I52NSmvFNMhyW2IHpIoUHW5jLkgUrknzJW1H/qxVGSIrNNVQkfsoaDFzDhJdg10pgrA==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/types": "1.383.1"
+        "@posthog/types": "1.386.3"
       }
     },
     "node_modules/@posthog/types": {
-      "version": "1.383.1",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.383.1.tgz",
-      "integrity": "sha512-1gdoBJLAbj9MjPnFV+WH+KWOktJIiWNvg8KO68cX3nbXlCCMx6p+d0e6ORmHshe1++UoRRIbSjfJE2aBOUVpRQ==",
+      "version": "1.386.3",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.386.3.tgz",
+      "integrity": "sha512-LqJoiQi2eyWn7rCUgnn+D+F3Efp6+04o72bjSX6kWHx0nFaYNC/nJuAIRliDTY/X7GPIUAaHAcSjbMI/9wfX1Q==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
@@ -2190,14 +2727,14 @@
       "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
-      "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@standard-schema/utils": "^0.3.0",
-        "immer": "^10.0.3",
+        "immer": "^11.0.0",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0",
         "reselect": "^5.1.0"
@@ -2215,10 +2752,313 @@
         }
       }
     },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -2228,9 +3068,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.108.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.0.tgz",
-      "integrity": "sha512-0CzVGVqHfNOhRQVEcAmu58Mex2Ce0zL3aGfyV+iFQjTK6OntLK/hLCLr/VDRX0E8/2CdsiY99L7fZ/8ys/op4w==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.1.tgz",
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2240,9 +3080,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.108.0",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.0.tgz",
-      "integrity": "sha512-lqEGDzT7QBUuKYzi5lHpV/XecXT9wikzcbXMbFo6krNpSDynD1sHM8wcsfB/BAqa4NkFuy3vF4JCV8MeakV8IQ==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.1.tgz",
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2258,9 +3098,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.108.0",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.0.tgz",
-      "integrity": "sha512-8AwTkPqowDYv/qh016CyXeZ3Ukpw6NHyfqc7DWV4afLR2hAiapf3zRKV2ZLG+//T1LK84HrR6X8VBwfgHWmNyw==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.1.tgz",
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2270,9 +3110,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.108.0",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.0.tgz",
-      "integrity": "sha512-N3xR0u7TNr+c5wuLSU60rcfu/H/8N0WBs7iHWwjI/NxKwY3XWSyLUbpbpU8bzmL0dA/Gk9Mupri8mxKUXBW+iw==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.1.tgz",
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
       "license": "MIT",
       "dependencies": {
         "@supabase/phoenix": "^0.4.2",
@@ -2283,9 +3123,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.108.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.0.tgz",
-      "integrity": "sha512-zMYQmh87CId7d8i/1FIfv4fMDcXPutmIJSpoY58GLXi7M266MNzxWGNabDk4i555Oj1Nqtsu2i3Qo3rpWUXO6A==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.1.tgz",
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -2296,16 +3136,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.108.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.0.tgz",
-      "integrity": "sha512-AjPoimM9MZLZbddnlDBGmpZ/Tas1dNcJvuZy/VD1AfmrjBC8J2RSw6UOqR4ISLLlEioOLca/5t1crFnAxa0wRQ==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.1.tgz",
+      "integrity": "sha512-V/1hRKLSCJ0zEL+9QFRBUtivvePfOsaAYQmC0HhFNSHC2F3xFs4jSF3YhkLmzex6E4V4FGvmBDOP72D/53NnZA==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.108.0",
-        "@supabase/functions-js": "2.108.0",
-        "@supabase/postgrest-js": "2.108.0",
-        "@supabase/realtime-js": "2.108.0",
-        "@supabase/storage-js": "2.108.0"
+        "@supabase/auth-js": "2.108.1",
+        "@supabase/functions-js": "2.108.1",
+        "@supabase/postgrest-js": "2.108.1",
+        "@supabase/realtime-js": "2.108.1",
+        "@supabase/storage-js": "2.108.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2629,6 +3469,54 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@trpc/client": {
       "version": "11.17.0",
       "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.17.0.tgz",
@@ -2676,6 +3564,35 @@
         "typescript": ">=5.7.2"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -2719,9 +3636,9 @@
       }
     },
     "node_modules/@types/d3-shape": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
-      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
@@ -2739,10 +3656,24 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
-      "version": "25.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2750,9 +3681,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2783,14 +3714,15 @@
       "license": "MIT"
     },
     "node_modules/@vercel/analytics": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
-      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
-      "license": "MPL-2.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
       "peerDependencies": {
         "@remix-run/react": "^2",
         "@sveltejs/kit": "^1 || ^2",
         "next": ">= 13",
+        "nuxt": ">= 3",
         "react": "^18 || ^19 || ^19.0.0-rc",
         "svelte": ">= 4",
         "vue": "^3",
@@ -2804,6 +3736,9 @@
           "optional": true
         },
         "next": {
+          "optional": true
+        },
+        "nuxt": {
           "optional": true
         },
         "react": {
@@ -2820,6 +3755,142 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -2830,6 +3901,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/autoprefixer": {
@@ -2869,15 +3960,25 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.18",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
-      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
+      "version": "2.10.36",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.36.tgz",
+      "integrity": "sha512-lVq/Df7LXlO79MVaaUHztSwWiG9oXoWHlgvNS51v8Dpd4+G4/VIy6qYePTw31nAVls33nUtnfezYeLkYAak9dg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -2914,9 +4015,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001787",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2932,6 +4033,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -2976,6 +4087,13 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/copy-anything": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
@@ -3000,6 +4118,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/csstype": {
@@ -3040,9 +4172,9 @@
       }
     },
     "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3130,6 +4262,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
@@ -3140,11 +4286,28 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -3162,19 +4325,26 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.9.tgz",
+      "integrity": "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.336",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
-      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
+      "version": "1.5.371",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
+      "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
       "license": "ISC"
     },
     "node_modules/embla-carousel": {
@@ -3206,9 +4376,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.23.0.tgz",
-      "integrity": "sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3219,10 +4389,30 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-toolkit": {
-      "version": "1.39.10",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
-      "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -3238,11 +4428,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fflate": {
       "version": "0.4.8",
@@ -3263,10 +4491,25 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/geist": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/geist/-/geist-1.7.0.tgz",
-      "integrity": "sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/geist/-/geist-1.7.2.tgz",
+      "integrity": "sha512-Gu5lDFa3pLRyoBlBPf0QIFHVdWAnpco7fS1bJm41jyLPFoguBgiubseUN2oLXMgqZ7uxAxDoXcHMhCY/fOTTgg==",
       "license": "SIL OPEN FONT LICENSE",
       "peerDependencies": {
         "next": ">=13.2.0"
@@ -3285,8 +4528,20 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
@@ -3298,9 +4553,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
-      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3326,6 +4581,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-what": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
@@ -3346,6 +4608,54 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/lightningcss": {
@@ -3621,6 +4931,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
@@ -3628,6 +4948,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -3639,6 +4969,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -3659,12 +4996,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.7.tgz",
-      "integrity": "sha512-eMJxgjRzBaj3olkP4cBamHDXL79A8FC6u1GcsO1D1Tsx8bw/LLXUJCaoajVxtnhD3A1IJqIT8IcRJjgBIPJq4w==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
+      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.7",
+        "@next/env": "16.2.9",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -3678,14 +5015,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.7",
-        "@next/swc-darwin-x64": "16.2.7",
-        "@next/swc-linux-arm64-gnu": "16.2.7",
-        "@next/swc-linux-arm64-musl": "16.2.7",
-        "@next/swc-linux-x64-gnu": "16.2.7",
-        "@next/swc-linux-x64-musl": "16.2.7",
-        "@next/swc-win32-arm64-msvc": "16.2.7",
-        "@next/swc-win32-x64-msvc": "16.2.7",
+        "@next/swc-darwin-arm64": "16.2.9",
+        "@next/swc-darwin-x64": "16.2.9",
+        "@next/swc-linux-arm64-gnu": "16.2.9",
+        "@next/swc-linux-arm64-musl": "16.2.9",
+        "@next/swc-linux-x64-gnu": "16.2.9",
+        "@next/swc-linux-x64-musl": "16.2.9",
+        "@next/swc-win32-arm64-msvc": "16.2.9",
+        "@next/swc-win32-x64-msvc": "16.2.9",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -3750,15 +5087,18 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
-      "license": "MIT"
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/npm": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.16.0.tgz",
-      "integrity": "sha512-A74XL8OxmcegZDMWPkWb5bEQppg8HdYwW3rBD2sPoS4UQHVajfaxBkqyzLeJ3wR0kZ+5xoTjItxXaF7eIXUsyw==",
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
+      "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -3836,8 +5176,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.7.0",
-        "@npmcli/config": "^10.10.0",
+        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/config": "^10.11.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -3861,11 +5201,11 @@
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.9",
-        "libnpmexec": "^10.2.9",
-        "libnpmfund": "^7.0.23",
+        "libnpmdiff": "^8.1.10",
+        "libnpmexec": "^10.3.0",
+        "libnpmfund": "^7.0.24",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.9",
+        "libnpmpack": "^9.1.10",
         "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -3875,7 +5215,7 @@
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.3.0",
+        "node-gyp": "^12.4.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -3885,16 +5225,16 @@
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.5.0",
+        "pacote": "^21.5.1",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.8.1",
+        "semver": "^7.8.4",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.15",
+        "tar": "^7.5.16",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -3949,7 +5289,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.7.0",
+      "version": "9.8.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3996,7 +5336,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.10.0",
+      "version": "10.11.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4653,11 +5993,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.9",
+      "version": "8.1.10",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.7.0",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -4671,12 +6011,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.9",
+      "version": "10.3.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.7.0",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -4693,11 +6033,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.23",
+      "version": "7.0.24",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.7.0"
+        "@npmcli/arborist": "^9.8.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -4716,11 +6056,11 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.9",
+      "version": "9.1.10",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.7.0",
+        "@npmcli/arborist": "^9.8.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -4946,7 +6286,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.3.0",
+      "version": "12.4.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5110,7 +6450,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.5.0",
+      "version": "21.5.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5168,7 +6508,7 @@
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
+      "version": "7.1.4",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5255,7 +6595,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.8.1",
+      "version": "7.8.4",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -5369,7 +6709,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.15",
+      "version": "7.5.16",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5394,7 +6734,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.16",
+      "version": "0.2.17",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5518,11 +6858,58 @@
         "node": ">=18"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.15",
@@ -5559,13 +6946,13 @@
       "license": "MIT"
     },
     "node_modules/posthog-js": {
-      "version": "1.383.1",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.383.1.tgz",
-      "integrity": "sha512-og2XbBCv2KkbDHgeu4Km8ivKdQRtb9HsUUORIwykRFMuBvZPoAFbmCvArnifm/4t2PAvWfn1bMmOr5bkHirNGg==",
+      "version": "1.386.6",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.386.6.tgz",
+      "integrity": "sha512-xRcbToRtU07Ojk+VaCCos6I/zD60sNKfWxdeZih0xbncgegIqLZJmBzi4HdkSkXrf14b6HhwMI/s2GxWha5ADQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@posthog/core": "1.30.12",
-        "@posthog/types": "1.383.1",
+        "@posthog/core": "^1.32.3",
+        "@posthog/types": "^1.386.3",
         "core-js": "^3.38.1",
         "dompurify": "^3.3.2",
         "fflate": "^0.4.8",
@@ -5575,13 +6962,45 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.29.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
-      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/query-selector-shadow-dom": {
@@ -5626,15 +7045,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-hook-form": {
@@ -5660,9 +7079,9 @@
       "license": "MIT"
     },
     "node_modules/react-redux": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
-      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
@@ -5806,11 +7225,68 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -5819,11 +7295,10 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5876,6 +7351,13 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -5894,6 +7376,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -5929,6 +7425,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
@@ -5975,6 +7478,96 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6002,6 +7595,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -6128,11 +7731,261 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-vitals": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
-      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
       "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -5,8 +5,10 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev",
-    "lint": "next lint",
-    "start": "next start"
+    "lint": "biome lint .",
+    "start": "next start",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.4.0",
@@ -58,7 +60,7 @@
     "posthog-js": "^1.383.1",
     "react": "^19.2.7",
     "react-day-picker": "10.0.1",
-    "react-dom": "^19",
+    "react-dom": "^19.2.7",
     "react-hook-form": "^7.78.0",
     "react-is": "^19.2.7",
     "react-resizable-panels": "^4.11.2",
@@ -71,14 +73,19 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.16",
     "@tailwindcss/postcss": "^4.3.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^25",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5",
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "1.4.0",
-    "typescript": "^6"
+    "typescript": "^6",
+    "vitest": "^4.1.8"
   },
   "engines": {
     "node": ">=22"

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['**/*.test.{ts,tsx}'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname),
+    },
+  },
+})

--- a/apps/post-extraction/openai_client.py
+++ b/apps/post-extraction/openai_client.py
@@ -14,6 +14,9 @@ from shared.openai_extractor import BaseOpenAIExtractor
 class OpenAIClient(BaseOpenAIExtractor):
     """Extracts ExtractedFeatures from Reddit posts via GPT-5-nano."""
 
+    # Routes same-prefix requests to the same OpenAI cache shard
+    PROMPT_CACHE_KEY = "whichglp-post-extraction"
+
     def extract_features(
         self,
         prompts: "tuple[str, str] | str",

--- a/apps/post-extraction/railway.json
+++ b/apps/post-extraction/railway.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
-    "builder": "NIXPACKS"
+    "builder": "NIXPACKS",
+    "nixpacksConfigPath": "apps/post-extraction/nixpacks.toml"
   },
   "deploy": {
     "healthcheckPath": "/health",

--- a/apps/post-ingestion/railway.json
+++ b/apps/post-ingestion/railway.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
-    "builder": "NIXPACKS"
+    "builder": "NIXPACKS",
+    "nixpacksConfigPath": "apps/post-ingestion/nixpacks.toml"
   },
   "deploy": {
     "healthcheckPath": "/health",

--- a/apps/rec-engine/railway.json
+++ b/apps/rec-engine/railway.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
-    "builder": "NIXPACKS"
+    "builder": "NIXPACKS",
+    "nixpacksConfigPath": "apps/rec-engine/nixpacks.toml"
   },
   "deploy": {
     "healthcheckPath": "/health",

--- a/apps/user-extraction/README.md
+++ b/apps/user-extraction/README.md
@@ -133,8 +133,9 @@ REDDIT_API_APP_SECRET=your-app-secret
 
 1. Create new Railway service: `whichglp-user-extraction`
 2. Link to GitHub repo
-3. Set root directory: `apps/user-extraction`
-4. Set start command: `./start.sh`
+3. Set root directory: `/` (monorepo root — the build commands in `nixpacks.toml` `cd` into `apps/user-extraction`)
+4. Set the config-as-code path to `apps/user-extraction/railway.json` (Settings → Config-as-code), which in turn points at `apps/user-extraction/nixpacks.toml` via `nixpacksConfigPath`
+5. The start command comes from `nixpacks.toml` (`cd apps/user-extraction && uvicorn api:app ...`)
 
 ### Environment Variables
 

--- a/apps/user-extraction/openai_client.py
+++ b/apps/user-extraction/openai_client.py
@@ -14,13 +14,16 @@ from shared.openai_extractor import BaseOpenAIExtractor, OpenAIExtractionError  
 class OpenAIClient(BaseOpenAIExtractor):
     """Extracts UserDemographics from a Reddit user's post/comment history."""
 
+    # Routes same-prefix requests to the same OpenAI cache shard
+    PROMPT_CACHE_KEY = "whichglp-user-extraction"
+
     def extract_demographics(
         self,
-        user_prompt: str,
+        prompts: "tuple[str, str] | str",
         model: Optional[str] = None,
         max_retries: int = 3,
     ) -> Tuple[UserDemographics, Dict[str, Any]]:
-        return self.extract(user_prompt, UserDemographics, model=model, max_retries=max_retries)
+        return self.extract(prompts, UserDemographics, model=model, max_retries=max_retries)
 
 
 _client_instance: Optional[OpenAIClient] = None

--- a/apps/user-extraction/prompts.py
+++ b/apps/user-extraction/prompts.py
@@ -409,9 +409,13 @@ Return ONLY valid JSON matching this EXACT schema (no markdown, no explanations)
 THIS IS EXPENSIVE. EXTRACT EVERY AVAILABLE DEMOGRAPHIC. GET IT RIGHT."""
 
 
-def build_user_prompt(username: str, posts: list, comments: list) -> str:
+def build_user_prompt(username: str, posts: list, comments: list) -> tuple[str, str]:
     """
-    Build prompt for demographic extraction from user's post/comment history.
+    Build prompts for demographic extraction from user's post/comment history.
+
+    The static SYSTEM_PROMPT is returned separately from the volatile user
+    history so it forms a byte-stable prefix for OpenAI prompt caching (the
+    system prompt alone exceeds the 1024-token caching minimum).
 
     Args:
         username: Reddit username (without u/ prefix)
@@ -419,7 +423,7 @@ def build_user_prompt(username: str, posts: list, comments: list) -> str:
         comments: List of comment dictionaries with 'body' key
 
     Returns:
-        Formatted prompt string
+        Tuple of (system_prompt, user_prompt)
     """
     # Format posts (tolerate None lists and None/empty title/body; skip empties)
     posts_text = ""
@@ -438,10 +442,8 @@ def build_user_prompt(username: str, posts: list, comments: list) -> str:
             continue
         comments_text += f"\n## Comment {i}:\n{body}\n"
 
-    # Build full prompt
-    prompt = f"""{SYSTEM_PROMPT}
-
-===== USER HISTORY FOR u/{username} =====
+    # Volatile content only — the static instructions live in SYSTEM_PROMPT
+    user_prompt = f"""===== USER HISTORY FOR u/{username} =====
 
 ### Recent Posts:
 {posts_text if posts_text else "(No posts)"}
@@ -453,4 +455,4 @@ def build_user_prompt(username: str, posts: list, comments: list) -> str:
 
 Analyze the above posts and comments to extract demographic information. Return ONLY the JSON object."""
 
-    return prompt
+    return SYSTEM_PROMPT, user_prompt

--- a/apps/user-extraction/railway.json
+++ b/apps/user-extraction/railway.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
-    "builder": "NIXPACKS"
+    "builder": "NIXPACKS",
+    "nixpacksConfigPath": "apps/user-extraction/nixpacks.toml"
   },
   "deploy": {
     "healthcheckPath": "/health",

--- a/apps/user-extraction/user_analyzer.py
+++ b/apps/user-extraction/user_analyzer.py
@@ -177,12 +177,12 @@ class RedditUserAnalyzer:
 
             return None
 
-        # Build prompt
-        prompt = build_user_prompt(username, posts, comments)
+        # Build (system_prompt, user_prompt) — system stays static for prompt caching
+        prompts = build_user_prompt(username, posts, comments)
 
         # Extract demographics with GPT-5-nano
         try:
-            demographics, metadata = self.ai_client.extract_demographics(prompt)
+            demographics, metadata = self.ai_client.extract_demographics(prompts)
 
             # Build database row
             user_data = {

--- a/scripts/legacy-ingestion/extraction/prompts.py
+++ b/scripts/legacy-ingestion/extraction/prompts.py
@@ -751,9 +751,9 @@ THIS IS EXPENSIVE. GET IT RIGHT THE FIRST TIME. EXTRACT EVERYTHING AVAILABLE.
 
 def build_post_prompt(
     subreddit: str, title: str, body: str, author_flair: str = ""
-) -> str:
+) -> tuple[str, str]:
     """
-    Build extraction prompt for a Reddit post (no comment chain).
+    Build extraction prompts for a Reddit post (no comment chain).
 
     Args:
         title: Post title
@@ -761,7 +761,7 @@ def build_post_prompt(
         author_flair: Author flair text (may contain structured data)
 
     Returns:
-        Formatted user prompt for the model
+        Tuple of (system_prompt, user_prompt)
     """
     # Tolerate None/empty inputs so the prompt never contains the literal "None".
     subreddit = (subreddit or "").strip()

--- a/scripts/legacy-ingestion/shared/openai_extractor.py
+++ b/scripts/legacy-ingestion/shared/openai_extractor.py
@@ -11,7 +11,7 @@ GPT-5-nano is a reasoning model, so it does NOT accept sampling parameters
 low-latency extraction is achieved with reasoning_effort="minimal" plus JSON
 response formatting.
 
-Cost (USD per 1M tokens): GPT-5-nano $0.05 / $0.40.
+Cost (USD per 1M tokens): GPT-5-nano $0.05 input ($0.005 cached) / $0.40 output.
 Docs: https://developers.openai.com/api/docs/models/gpt-5-nano
 """
 
@@ -34,9 +34,10 @@ load_dotenv(Path(__file__).resolve().parents[3] / ".env")
 
 logger = get_logger(__name__)
 
-# OpenAI model pricing (USD per million tokens)
+# OpenAI model pricing (USD per million tokens). "input_cached" is the rate for
+# prompt-cache hits (90% discount on the gpt-5 family).
 MODEL_PRICING: Dict[str, Dict[str, float]] = {
-    "gpt-5-nano": {"input": 0.05, "output": 0.40},
+    "gpt-5-nano": {"input": 0.05, "input_cached": 0.005, "output": 0.40},
 }
 
 DEFAULT_MODEL = "gpt-5-nano"
@@ -59,12 +60,23 @@ class BaseOpenAIExtractor:
 
     Subclasses expose a domain method (e.g. extract_features / extract_demographics)
     that calls self.extract(prompts, TheirPydanticModel).
+
+    Prompt caching: prompts must keep the static system prompt as a byte-stable
+    prefix (volatile content only in the user message) so OpenAI's automatic
+    prefix caching (≥1024 tokens) hits. Subclasses should set PROMPT_CACHE_KEY
+    to a per-service constant — OpenAI combines it with the prefix hash to route
+    same-prefix traffic to the same machine, improving hit rates.
     """
 
-    def __init__(self, api_key: Optional[str] = None):
+    # Per-service prompt-cache routing key (override in subclasses).
+    PROMPT_CACHE_KEY: Optional[str] = None
+
+    def __init__(self, api_key: Optional[str] = None, prompt_cache_key: Optional[str] = None):
         """
         Args:
             api_key: OpenAI API key (defaults to the OPENAI_API_KEY env var).
+            prompt_cache_key: cache-routing key (defaults to the class's
+                PROMPT_CACHE_KEY).
 
         Raises:
             ValueError: if no API key is available.
@@ -75,13 +87,30 @@ class BaseOpenAIExtractor:
                 "OPENAI_API_KEY not found. Set it in your .env file. "
                 "Get a key at: https://platform.openai.com/api-keys"
             )
+        # `is None` (not `or`) so an explicit "" can disable a subclass's key
+        self.prompt_cache_key = (
+            prompt_cache_key if prompt_cache_key is not None else self.PROMPT_CACHE_KEY
+        )
         self.client = OpenAI(api_key=self.api_key)
         logger.info("OpenAI client initialized")
 
-    def calculate_cost(self, model: str, tokens_input: int, tokens_output: int) -> float:
-        """Return the USD cost of a call given token counts."""
+    def calculate_cost(
+        self, model: str, tokens_input: int, tokens_output: int, tokens_input_cached: int = 0
+    ) -> float:
+        """
+        Return the USD cost of a call given token counts.
+
+        `tokens_input` is the TOTAL prompt tokens (cache hits included);
+        `tokens_input_cached` is the cached subset, billed at the discounted rate.
+        """
         pricing = MODEL_PRICING.get(model, MODEL_PRICING[DEFAULT_MODEL])
-        return (tokens_input / 1_000_000) * pricing["input"] + (tokens_output / 1_000_000) * pricing["output"]
+        tokens_input_cached = min(tokens_input_cached or 0, tokens_input)
+        tokens_input_uncached = tokens_input - tokens_input_cached
+        return (
+            (tokens_input_uncached / 1_000_000) * pricing["input"]
+            + (tokens_input_cached / 1_000_000) * pricing.get("input_cached", pricing["input"])
+            + (tokens_output / 1_000_000) * pricing["output"]
+        )
 
     def extract(
         self,
@@ -114,6 +143,11 @@ class BaseOpenAIExtractor:
 
         messages = self._build_messages(prompts, default_system_prompt)
 
+        # Steer same-prefix requests to the same cache shard when a key is set.
+        cache_kwargs: Dict[str, Any] = (
+            {"prompt_cache_key": self.prompt_cache_key} if self.prompt_cache_key else {}
+        )
+
         for attempt in range(max_retries):
             try:
                 start_time = time.time()
@@ -122,6 +156,7 @@ class BaseOpenAIExtractor:
                     messages=messages,
                     reasoning_effort=DEFAULT_REASONING_EFFORT,
                     response_format={"type": "json_object"},
+                    **cache_kwargs,
                 )
                 processing_time_ms = int((time.time() - start_time) * 1000)
 
@@ -136,12 +171,21 @@ class BaseOpenAIExtractor:
 
                 tokens_input = response.usage.prompt_tokens
                 tokens_output = response.usage.completion_tokens
-                cost_usd = self.calculate_cost(model, tokens_input, tokens_output)
+                # Prompt-cache hits (usage.prompt_tokens_details.cached_tokens);
+                # tracked so cost is right and cache regressions are visible in logs.
+                # Clamped to total prompt tokens so cost and hit rate stay consistent.
+                prompt_details = getattr(response.usage, "prompt_tokens_details", None)
+                tokens_input_cached = min(
+                    getattr(prompt_details, "cached_tokens", 0) or 0, tokens_input
+                )
+                cost_usd = self.calculate_cost(model, tokens_input, tokens_output, tokens_input_cached)
+                cache_hit_rate = (tokens_input_cached / tokens_input) if tokens_input else 0.0
 
                 metadata = {
                     "model": model,
                     "cost_usd": cost_usd,
                     "tokens_input": tokens_input,
+                    "tokens_input_cached": tokens_input_cached,
                     "tokens_output": tokens_output,
                     "processing_time_ms": processing_time_ms,
                     "raw_response": {
@@ -151,6 +195,7 @@ class BaseOpenAIExtractor:
                         "finish_reason": response.choices[0].finish_reason,
                         "usage": {
                             "prompt_tokens": tokens_input,
+                            "cached_tokens": tokens_input_cached,
                             "completion_tokens": tokens_output,
                             "total_tokens": getattr(
                                 response.usage, "total_tokens", tokens_input + tokens_output
@@ -161,7 +206,9 @@ class BaseOpenAIExtractor:
 
                 logger.info(
                     f"Extraction successful - Model: {model}, Cost: ${cost_usd:.6f}, "
-                    f"Tokens: {tokens_input}/{tokens_output}, Time: {processing_time_ms}ms"
+                    f"Tokens: {tokens_input}/{tokens_output} "
+                    f"(cached: {tokens_input_cached}, hit rate: {cache_hit_rate:.0%}), "
+                    f"Time: {processing_time_ms}ms"
                 )
                 return result, metadata
 

--- a/scripts/tests/test_full_user_analysis.py
+++ b/scripts/tests/test_full_user_analysis.py
@@ -58,14 +58,14 @@ for comment in redditor.comments.new(limit=5):
 
 print(f"✓ Fetched {len(posts)} posts, {len(comments)} comments")
 
-# Build prompt
-prompt = build_user_prompt(username, posts, comments)
-print(f"✓ Built prompt ({len(prompt)} chars)")
+# Build prompts (system_prompt, user_prompt) — system stays static for prompt caching
+prompts = build_user_prompt(username, posts, comments)
+print(f"✓ Built prompts ({sum(len(p) for p in prompts)} chars)")
 
 # Extract with GPT-5-nano
 ai_client = get_client()
 print("✓ Calling OpenAI API...")
-demographics, metadata = ai_client.extract_demographics(prompt)
+demographics, metadata = ai_client.extract_demographics(prompts)
 
 print("\n✓ EXTRACTION SUCCESSFUL")
 print(f"  Cost: ${metadata['cost_usd']:.6f}")

--- a/scripts/tests/test_openai_client.py
+++ b/scripts/tests/test_openai_client.py
@@ -30,15 +30,15 @@ test_comments = [
 print("Testing OpenAI client...")
 print("=" * 60)
 
-# Build prompt
-prompt = build_user_prompt("test_user", test_posts, test_comments)
+# Build prompts (system_prompt, user_prompt) — system stays static for prompt caching
+prompts = build_user_prompt("test_user", test_posts, test_comments)
 
-print(f"\nPrompt length: {len(prompt)} chars")
+print(f"\nPrompt length: {sum(len(p) for p in prompts)} chars")
 print("\nCalling OpenAI API...")
 
 # Get client and extract
 client = get_client()
-demographics, metadata = client.extract_demographics(prompt)
+demographics, metadata = client.extract_demographics(prompts)
 
 print("\n" + "=" * 60)
 print("EXTRACTION SUCCESSFUL!")

--- a/scripts/tests/test_openai_client_unit.py
+++ b/scripts/tests/test_openai_client_unit.py
@@ -35,7 +35,7 @@ class StrictModel(BaseModel):
 
 
 def make_response(content, prompt_tokens=100, completion_tokens=20,
-                  finish_reason="stop", response_id="resp_1"):
+                  finish_reason="stop", response_id="resp_1", cached_tokens=None):
     message = types.SimpleNamespace(content=content)
     choice = types.SimpleNamespace(message=message, finish_reason=finish_reason)
     usage = types.SimpleNamespace(
@@ -43,6 +43,8 @@ def make_response(content, prompt_tokens=100, completion_tokens=20,
         completion_tokens=completion_tokens,
         total_tokens=prompt_tokens + completion_tokens,
     )
+    if cached_tokens is not None:
+        usage.prompt_tokens_details = types.SimpleNamespace(cached_tokens=cached_tokens)
     return types.SimpleNamespace(id=response_id, choices=[choice], usage=usage, model="gpt-5-nano")
 
 
@@ -197,6 +199,110 @@ def test_metadata_shape():
     assert metadata["raw_response"]["id"] == "resp_42"
     assert metadata["raw_response"]["finish_reason"] == "stop"
     assert metadata["raw_response"]["usage"]["total_tokens"] == 120
+
+
+# --------------------------------------------------------------------------
+# Prompt caching: cost, metadata, and prompt_cache_key routing
+# --------------------------------------------------------------------------
+
+def test_calculate_cost_discounts_cached_input():
+    ex = build_extractor([])
+    # 1M prompt tokens of which 800k cached, 1M output:
+    # 0.2M × $0.05/M + 0.8M × $0.005/M + 1M × $0.40/M = 0.414
+    cost = ex.calculate_cost("gpt-5-nano", 1_000_000, 1_000_000, tokens_input_cached=800_000)
+    assert cost == pytest.approx(0.414)
+
+
+def test_calculate_cost_clamps_cached_to_total_input():
+    ex = build_extractor([])
+    fully_cached = ex.calculate_cost("gpt-5-nano", 1_000_000, 0, tokens_input_cached=1_000_000)
+    over_reported = ex.calculate_cost("gpt-5-nano", 1_000_000, 0, tokens_input_cached=2_000_000)
+    assert over_reported == pytest.approx(fully_cached) == pytest.approx(0.005)
+
+
+def test_calculate_cost_cached_none_treated_as_zero():
+    ex = build_extractor([])
+    assert ex.calculate_cost("gpt-5-nano", 1_000_000, 0, tokens_input_cached=None) == pytest.approx(0.05)
+
+
+def test_calculate_cost_unknown_model_without_cached_rate_charges_full_input():
+    # Fallback pricing has no "input_cached" guarantee — must not crash or discount wrongly.
+    ex = build_extractor([])
+    pricing = {"input": 1.0, "output": 2.0}
+    oe.MODEL_PRICING["test-model-no-cache-rate"] = pricing
+    try:
+        cost = ex.calculate_cost("test-model-no-cache-rate", 1_000_000, 0, tokens_input_cached=500_000)
+        assert cost == pytest.approx(1.0)  # cached portion billed at full input rate
+    finally:
+        del oe.MODEL_PRICING["test-model-no-cache-rate"]
+
+
+def test_metadata_includes_cached_tokens_and_discounted_cost():
+    ex = build_extractor([make_response('{"summary": "ok"}', prompt_tokens=100,
+                                        completion_tokens=20, cached_tokens=60)])
+    _, metadata = ex.extract("x", passthrough)
+    assert metadata["tokens_input_cached"] == 60
+    assert metadata["raw_response"]["usage"]["cached_tokens"] == 60
+    assert metadata["cost_usd"] == pytest.approx(ex.calculate_cost("gpt-5-nano", 100, 20, 60))
+
+
+def test_metadata_cached_tokens_defaults_to_zero_when_details_missing():
+    # Older/partial SDK responses may omit prompt_tokens_details entirely.
+    ex = build_extractor([make_response('{"summary": "ok"}')])
+    _, metadata = ex.extract("x", passthrough)
+    assert metadata["tokens_input_cached"] == 0
+
+
+def test_metadata_clamps_over_reported_cached_tokens():
+    ex = build_extractor([make_response('{"summary": "ok"}', prompt_tokens=100, cached_tokens=150)])
+    _, metadata = ex.extract("x", passthrough)
+    assert metadata["tokens_input_cached"] == 100
+
+
+def test_prompt_cache_key_forwarded_when_subclass_sets_it():
+    class KeyedExtractor(BaseOpenAIExtractor):
+        PROMPT_CACHE_KEY = "whichglp-test"
+
+    ex = KeyedExtractor(api_key="sk-test")
+    ex.client = _FakeClient([make_response('{"x": 1}')])
+    ex.extract("hello", passthrough)
+    assert ex.client.chat.completions.calls[0]["prompt_cache_key"] == "whichglp-test"
+
+
+def test_prompt_cache_key_omitted_when_unset():
+    ex = build_extractor([make_response('{"x": 1}')])
+    ex.extract("hello", passthrough)
+    assert "prompt_cache_key" not in ex.client.chat.completions.calls[0]
+
+
+def test_prompt_cache_key_empty_string_disables_class_key():
+    class KeyedExtractor(BaseOpenAIExtractor):
+        PROMPT_CACHE_KEY = "whichglp-test"
+
+    ex = KeyedExtractor(api_key="sk-test", prompt_cache_key="")
+    ex.client = _FakeClient([make_response('{"x": 1}')])
+    ex.extract("hello", passthrough)
+    assert "prompt_cache_key" not in ex.client.chat.completions.calls[0]
+
+
+def test_prompt_cache_key_constructor_arg_overrides_class_key():
+    class KeyedExtractor(BaseOpenAIExtractor):
+        PROMPT_CACHE_KEY = "class-key"
+
+    ex = KeyedExtractor(api_key="sk-test", prompt_cache_key="ctor-key")
+    ex.client = _FakeClient([make_response('{"x": 1}')])
+    ex.extract("hello", passthrough)
+    assert ex.client.chat.completions.calls[0]["prompt_cache_key"] == "ctor-key"
+
+
+def test_prompt_cache_key_sent_on_every_retry_attempt():
+    class KeyedExtractor(BaseOpenAIExtractor):
+        PROMPT_CACHE_KEY = "whichglp-test"
+
+    ex = KeyedExtractor(api_key="sk-test")
+    ex.client = _FakeClient([Exception("boom"), make_response('{"x": 1}')])
+    ex.extract("hello", passthrough)
+    assert all(c["prompt_cache_key"] == "whichglp-test" for c in ex.client.chat.completions.calls)
 
 
 # --------------------------------------------------------------------------

--- a/scripts/tests/test_user_extraction_prompts.py
+++ b/scripts/tests/test_user_extraction_prompts.py
@@ -1,0 +1,105 @@
+"""
+Unit tests for apps/user-extraction/prompts.py (offline, no API).
+
+Verifies the prompt-caching split: build_user_prompt must return
+(system_prompt, user_prompt) where the system prompt is the byte-stable
+static prefix and ONLY the volatile user history lives in the user prompt.
+
+Loaded via importlib (not sys.path) because other test modules import a
+different module also named `prompts`.
+
+Run: venv/bin/pytest scripts/tests/test_user_extraction_prompts.py -q
+"""
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PROMPTS_PATH = ROOT / "apps" / "user-extraction" / "prompts.py"
+
+spec = importlib.util.spec_from_file_location("user_extraction_prompts", PROMPTS_PATH)
+prompts_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(prompts_module)
+
+build_user_prompt = prompts_module.build_user_prompt
+SYSTEM_PROMPT = prompts_module.SYSTEM_PROMPT
+
+
+def make_history(post_count=1, comment_count=1):
+    # "PTitle"/"CBody" avoid colliding with the builder's own "## Post N:" headers
+    posts = [{"title": f"PTitle {i}", "body": f"PBody {i}"} for i in range(post_count)]
+    comments = [{"body": f"CBody {i}"} for i in range(comment_count)]
+    return posts, comments
+
+
+# --------------------------------------------------------------------------
+# Prompt-caching split
+# --------------------------------------------------------------------------
+
+def test_returns_system_and_user_tuple():
+    posts, comments = make_history()
+    result = build_user_prompt("tester", posts, comments)
+    assert isinstance(result, tuple) and len(result) == 2
+    system_prompt, user_prompt = result
+    assert system_prompt == SYSTEM_PROMPT
+    assert isinstance(user_prompt, str)
+
+
+def test_system_prompt_not_duplicated_into_user_prompt():
+    _, user_prompt = build_user_prompt("tester", *make_history())
+    assert SYSTEM_PROMPT not in user_prompt
+
+
+def test_user_prompt_contains_only_volatile_history():
+    _, user_prompt = build_user_prompt("tester", *make_history())
+    assert "u/tester" in user_prompt
+    assert "PTitle 0" in user_prompt and "PBody 0" in user_prompt
+    assert "CBody 0" in user_prompt
+
+
+def test_system_prompt_is_static_across_calls():
+    sys_a, _ = build_user_prompt("alice", *make_history(3, 3))
+    sys_b, _ = build_user_prompt("bob", [], [])
+    assert sys_a == sys_b  # byte-identical prefix regardless of input
+
+
+# --------------------------------------------------------------------------
+# Empty / None handling
+# --------------------------------------------------------------------------
+
+def test_empty_history_uses_placeholders():
+    _, user_prompt = build_user_prompt("tester", [], [])
+    assert "(No posts)" in user_prompt
+    assert "(No comments)" in user_prompt
+
+
+def test_none_lists_tolerated():
+    _, user_prompt = build_user_prompt("tester", None, None)
+    assert "(No posts)" in user_prompt
+    assert "(No comments)" in user_prompt
+
+
+def test_none_and_whitespace_items_skipped():
+    posts = [{"title": None, "body": None}, {"title": "  ", "body": "\n"}]
+    comments = [{"body": None}, {"body": "   "}]
+    _, user_prompt = build_user_prompt("tester", posts, comments)
+    assert "(No posts)" in user_prompt
+    assert "(No comments)" in user_prompt
+    assert "None" not in user_prompt  # never leak the literal "None"
+
+
+def test_post_with_title_but_empty_body_is_kept():
+    posts = [{"title": "Only title", "body": ""}]
+    _, user_prompt = build_user_prompt("tester", posts, [])
+    assert "Only title" in user_prompt
+
+
+# --------------------------------------------------------------------------
+# Truncation limits
+# --------------------------------------------------------------------------
+
+def test_posts_and_comments_capped_at_twenty():
+    posts, comments = make_history(post_count=25, comment_count=25)
+    _, user_prompt = build_user_prompt("tester", posts, comments)
+    assert "PTitle 19" in user_prompt and "PTitle 20" not in user_prompt
+    assert "CBody 19" in user_prompt and "CBody 20" not in user_prompt


### PR DESCRIPTION
## Summary

Implements the new performance doctrines from CLAUDE.md across the frontend and the GPT-5-nano extraction services, and fixes a dead-config issue in the Railway deploy setup.

### Frontend: aggressive prefetching + loading UX

- **`AppPrefetcher`** (mounted once in the root layout): whenever the user lands on any page, it idle-prefetches **all other top-level routes** (`router.prefetch`) **and warms their tRPC queries** (`platform.getStats`, `drugs.getAllStats`, `experiences.list` default view, `locations.getData`, `demographics.getData`, `platform.getTrends`). Since the dashboard fetches all five tabs' queries up front, this also covers tab prefetching. Everything runs via `requestIdleCallback` (with a Safari `setTimeout` fallback) so it never competes with the current page.
- **Hover-intent prefetch (200ms)**: experience cards prefetch their `getById` detail; drug-comparison cards and recommendation results prefetch their `/experiences?drug=…` destination (route + warmed list query) via a shared `usePrefetchExperiences` hook.
- **Early next-page fetch**: the infinite-scroll observer now uses a `1000px` rootMargin so the next page loads well before the user reaches the bottom.
- **`LoadingDialog`** (new shadcn-style `components/ui` component): small floating dialog, **no scrim** (a scrim flashing on short loads is bad UI), appears only after a load runs >200ms (`useDelayedVisible`). Replaces the instant backdrop-blur overlay on the experiences filter path and covers the recommendations mutation.
- **Cache-key safety**: `buildExperiencesListInput` is the single source of truth for the `experiences.list` input, shared by the page and every prefetcher — verified (down to tRPC v11 key derivation and React Query `hashKey` semantics) that warmed entries are the exact entries the pages read.

### Extraction services: OpenAI prompt caching (GPT-5-nano)

- Per-service **`prompt_cache_key`** (`whichglp-post-extraction` / `whichglp-user-extraction`) on every call, steering same-prefix requests to the same OpenAI cache shard.
- **`cached_tokens` captured** from `usage.prompt_tokens_details` into metadata (`tokens_input_cached`), logged with per-call hit rate, and stored in `raw_response.usage` — cache regressions are now visible.
- **Cost math fixed**: cached input billed at $0.005/M (90% discount) instead of $0.05/M — previously every call was costed as fully uncached.
- **user-extraction prompt split**: `build_user_prompt` now returns `(SYSTEM_PROMPT, user_prompt)` instead of concatenating the ~6k-token static instructions into the user message, making the system prompt a byte-stable cacheable prefix (matches post-extraction's existing structure).

### Railway deploy fix

The four Python services' `nixpacks.toml` files assume monorepo-root builds (`cd apps/<service> && …`), but nothing referenced them — Nixpacks only auto-discovers configs at the build-context root. Each service's `railway.json` now sets `"nixpacksConfigPath"` explicitly (validated against Railway's JSON schema). Also fixed the contradictory deploy steps in `apps/user-extraction/README.md`.

> **Action needed (dashboard, can't be set from the repo):** each Python service's Settings → Config-as-code path must point at `apps/<service>/railway.json` for these files to take effect.

### Tooling, tests, docs

- **Biome** added to the frontend (`npm run lint`) — replaces the `next lint` script that Next 16 removed. New-code diagnostics are clean; remaining warnings are pre-existing patterns (`any`s, index keys, button types) left for a separate cleanup.
- **Tests**: 21 new vitest tests (`buildExperiencesListInput`, `runWhenIdle`, `useDelayedVisible`, `useHoverPrefetch` — happy paths, sweeps, resets, unmount cleanup) + 22 new pytest cases (cache-aware cost math incl. clamping and fallback pricing, metadata shape, `prompt_cache_key` routing/override/disable, prompt split, None/empty/truncation handling). Full suites green: 21 vitest, 81 pytest.
- **Packages**: `react`/`react-dom` aligned at 19.2.7 (they had drifted, breaking jsdom rendering); in-range updates applied (Next 16.2.9 etc.); the `@vercel/analytics` major left for Renovate.
- **Docs**: README (Node 22+, Next.js 16, deploy-config notes), CLAUDE.md (prefetching, loading-dialog, prompt-caching, Langfuse, tools/MCP doctrines).

## Test plan

- [x] `npm run build` (frontend) — passes
- [x] `npm run test` — 21/21
- [x] `npx tsc --noEmit` — clean
- [x] `pytest scripts/tests scripts/legacy-ingestion/tests` — 81 passed (2 pre-existing collection errors in DB-dependent legacy tests excluded; they require `psycopg2` + a live DB)
- [ ] After deploy: check extraction service logs for `cached: N (hit rate: X%)` lines to confirm cache hits in production
- [ ] Verify Railway dashboard config-as-code paths (see action needed above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)